### PR TITLE
New CMake variable VTK_VMTK_BUILD_STELLAR

### DIFF
--- a/vtkVmtk/CMakeLists.txt
+++ b/vtkVmtk/CMakeLists.txt
@@ -34,7 +34,6 @@ if(APPLE)
 endif(APPLE)
 
 OPTION(VTK_VMTK_BUILD_TETGEN "Build TetGen and TetGen wrapper." ON)
-OPTION(VTK_VMTK_BUILD_STELLAR "Build Stellar." ON)
 
 IF (VTK_USE_COCOA)
   OPTION(VTK_VMTK_USE_COCOA "Build the Cocoa vmtk classes." ON)

--- a/vtkVmtk/Utilities/CMakeLists.txt
+++ b/vtkVmtk/Utilities/CMakeLists.txt
@@ -1,12 +1,9 @@
 SUBDIRS(
   Doxygen
   OpenNL
+  Stellar_1.0
   vtkvmtkITK
   )
-
-IF (VTK_VMTK_BUILD_STELLAR)
-  SUBDIRS(Stellar_1.0)
-ENDIF (VTK_VMTK_BUILD_STELLAR)
 
 IF (VTK_VMTK_BUILD_TETGEN)
   SUBDIRS(tetgen1.4.3)


### PR DESCRIPTION
Hi Luca,

there are linking errors with Stellar on linux32 and linux64. At least when compiling as a Slicer3 and Slicer4 extension but probably also when compiling stand-alone vmtk.

For Slicer, I will use the new CMake variable to deactivate Stellar. 

Feel free to pull.

Daniel
