### PR TITLE
fixed vmtkmeshviewer2

### DIFF
--- a/vmtkScripts/contrib/vmtkmeshviewer2.py
+++ b/vmtkScripts/contrib/vmtkmeshviewer2.py
@@ -186,7 +186,7 @@ class vmtkMeshViewer2(pypes.pypeScript):
             self.vmtkRenderer.RenderWindow.Render()
 
     def UndoCallback(self,obj):
-	      self.ThresholdUpper = not self.ThresholdUpper
+        self.ThresholdUpper = not self.ThresholdUpper
         if self.DoThreshold:
             isClipped = (self.Actor.GetMapper().GetInput() != self.Mesh)
             self.ThresholdMesh()


### PR DESCRIPTION
Fixed vmtkmeshviewer2.py. 
There was a bad indentation in line 190.
