### PR TITLE
added triangle area ratio check

### DIFF
--- a/vtkVmtk/Misc/vtkvmtkBoundaryLayerGenerator.cxx
+++ b/vtkVmtk/Misc/vtkvmtkBoundaryLayerGenerator.cxx
@@ -637,7 +637,10 @@ int vtkvmtkBoundaryLayerGenerator::CheckTangle(vtkUnstructuredGrid* input, vtkUn
     vtkTriangle::ComputeNormal(basePoint1,basePoint2,basePoint3,baseNormal);
     vtkTriangle::ComputeNormal(warpedPoint1,warpedPoint2,warpedPoint3,warpedNormal);
     double prod = vtkMath::Dot(baseNormal,warpedNormal);
-    if (prod<0)
+    double baseArea = vtkTriangle::TriangleArea(basePoint1,basePoint2,basePoint3);
+    double warpedArea = vtkTriangle::TriangleArea(warpedPoint1,warpedPoint2,warpedPoint3);
+    double testArea = warpedArea / baseArea;    
+    if (prod < 0 || testArea <= 0.1 )
       {
       check = 1;
       found = found + 1;


### PR DESCRIPTION
I've chosen 0.1 because 0.05 (as we discussed yesterday) was too small. Now it works well on the examples that I have.
