### PR TITLE
Fix CMake warnings CMP0038

### DIFF
--- a/vtkVmtk/DifferentialGeometry/CMakeLists.txt
+++ b/vtkVmtk/DifferentialGeometry/CMakeLists.txt
@@ -68,7 +68,7 @@ SET_SOURCE_FILES_PROPERTIES (
 
 INCLUDE_DIRECTORIES(${VTK_VMTK_SOURCE_DIR}/Utilities/OpenNL)
 
-SET(VTK_VMTK_DIFFERENTIALGEOMETRY_TARGET_LINK_LIBRARIES vtkvmtkDifferentialGeometry vtkCommon vtkFiltering vtkGraphics vtkvmtkComputationalGeometry nl)
+SET(VTK_VMTK_DIFFERENTIALGEOMETRY_TARGET_LINK_LIBRARIES vtkCommon vtkFiltering vtkGraphics vtkvmtkComputationalGeometry nl)
 
 ADD_LIBRARY (vtkvmtkDifferentialGeometry ${VTK_VMTK_DIFFERENTIALGEOMETRY_SRCS})
 IF(VMTK_LIBRARY_PROPERTIES)

--- a/vtkVmtk/Misc/CMakeLists.txt
+++ b/vtkVmtk/Misc/CMakeLists.txt
@@ -30,7 +30,7 @@ SET (VTK_VMTK_MISC_SRCS
   vtkvmtkUnstructuredGridTetraFilter.cxx
   )
 
-SET (VTK_VMTK_MISC_TARGET_LINK_LIBRARIES vtkvmtkMisc vtkvmtkComputationalGeometry vtkvmtkDifferentialGeometry vtkCommon vtkFiltering vtkGraphics vtkHybrid)
+SET (VTK_VMTK_MISC_TARGET_LINK_LIBRARIES vtkvmtkComputationalGeometry vtkvmtkDifferentialGeometry vtkCommon vtkFiltering vtkGraphics vtkHybrid)
 
 IF (VTK_VMTK_BUILD_TETGEN)
   SET (VTK_VMTK_MISC_SRCS ${VTK_VMTK_MISC_SRCS} vtkvmtkTetGenWrapper.cxx)


### PR DESCRIPTION
This commit fixes the following warning happening when configuring using
CMake 3.2.1

// ----------------
CMake Warning (dev) at vtkVmtk/DifferentialGeometry/CMakeLists.txt:73 (ADD_LIBRARY):
  Policy CMP0038 is not set: Targets may not link directly to themselves.
  Run "cmake --help-policy CMP0038" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  Target "vtkvmtkDifferentialGeometry" links to itself.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at vtkVmtk/Misc/CMakeLists.txt:50 (ADD_LIBRARY):
  Policy CMP0038 is not set: Targets may not link directly to themselves.
  Run "cmake --help-policy CMP0038" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  Target "vtkvmtkMisc" links to itself.
This warning is for project developers.  Use -Wno-dev to suppress it.
// ----------------