### PR TITLE
Fixed Contrib for VTK 6

### DIFF
--- a/vtkVmtk/Contrib/vtkvmtkBoundaryLayerGenerator2.cxx
+++ b/vtkVmtk/Contrib/vtkvmtkBoundaryLayerGenerator2.cxx
@@ -39,6 +39,7 @@
 #include "vtkCellData.h"
 #include "vtkGeometryFilter.h"
 #include "vtkOrderedTriangulator.h"
+#include "vtkVersion.h"
 
 #include "vtkvmtkPolyDataBoundaryExtractor.h"
 

--- a/vtkVmtk/Contrib/vtkvmtkCellDimensionFilter.cxx
+++ b/vtkVmtk/Contrib/vtkvmtkCellDimensionFilter.cxx
@@ -32,6 +32,7 @@
 #include "vtkInformation.h"
 #include "vtkInformationVector.h"
 #include "vtkObjectFactory.h"
+#include "vtkVersion.h"
 
 
 vtkStandardNewMacro(vtkvmtkCellDimensionFilter);

--- a/vtkVmtk/Contrib/vtkvmtkCenterlineInterpolateArray.cxx
+++ b/vtkVmtk/Contrib/vtkvmtkCenterlineInterpolateArray.cxx
@@ -37,6 +37,7 @@
 #include "vtkInformationVector.h"
 #include "vtkObjectFactory.h"
 #include "vtkIOStream.h"
+#include "vtkVersion.h"
 
 #include "vtkvmtkConstants.h"
 #include "vtkvmtkCenterlineAttributesFilter.h"
@@ -133,7 +134,7 @@ int vtkvmtkCenterlineInterpolateArray::RequestData(
     output->GetPointData()->AddArray(interpolatedArray);
     }
     
-  int numberOfComponents = vtkstd::min(interpolatedArray->GetNumberOfComponents(),this->Values->GetNumberOfComponents());
+  int numberOfComponents = std::min(interpolatedArray->GetNumberOfComponents(),this->Values->GetNumberOfComponents());
     
   //Compute abscissas for the centerlines
   vtkvmtkCenterlineAttributesFilter *attribFilter = vtkvmtkCenterlineAttributesFilter::New();
@@ -191,7 +192,7 @@ int vtkvmtkCenterlineInterpolateArray::RequestData(
       
     //Otherwise we have our first value fill the previous points with this value
     startInd--;
-    vtkstd::vector<double> startVal(numberOfComponents);
+    std::vector<double> startVal(numberOfComponents);
     for (int j=0; j<numberOfComponents; j++)
       {
       startVal[j] = interpolatedArray->GetComponent(polyLine->GetPointId(startInd),j);
@@ -215,7 +216,7 @@ int vtkvmtkCenterlineInterpolateArray::RequestData(
       if (foundValue)
         {
         //Interpolate between the start and end values
-        vtkstd::vector<double> endVal(numberOfComponents);
+        std::vector<double> endVal(numberOfComponents);
         for (int j=0; j<numberOfComponents; j++)
           {
           endVal[j] = interpolatedArray->GetComponent(polyLine->GetPointId(endInd),j);

--- a/vtkVmtk/Contrib/vtkvmtkConcaveAnnularCapPolyData.cxx
+++ b/vtkVmtk/Contrib/vtkvmtkConcaveAnnularCapPolyData.cxx
@@ -39,6 +39,8 @@ Version:   $Revision: 1.0 $
 #include "vtkInformationVector.h"
 #include "vtkObjectFactory.h"
 #include "vtkSmartPointer.h"
+#include "vtkVersion.h"
+
 #include <limits>
 
 

--- a/vtkVmtk/Contrib/vtkvmtkPolyBallLine2.cxx
+++ b/vtkVmtk/Contrib/vtkvmtkPolyBallLine2.cxx
@@ -29,6 +29,7 @@
 #include "vtkPolyLine.h"
 #include "vtkMath.h"
 #include "vtkObjectFactory.h"
+#include "vtkVersion.h"
 
 
 vtkStandardNewMacro(vtkvmtkPolyBallLine2);

--- a/vtkVmtk/Contrib/vtkvmtkPolyDataDijkstraDistanceToPoints.cxx
+++ b/vtkVmtk/Contrib/vtkvmtkPolyDataDijkstraDistanceToPoints.cxx
@@ -37,8 +37,12 @@
 
 #include "vtkvmtkConstants.h"
 
-#if (VTK_MAJOR_VERSION >= 5) && (VTK_MINOR_VERSION >= 2)
+#if (VTK_MAJOR_VERSION > 5)
 #include "vtkDijkstraGraphGeodesicPath.h"
+#else
+#if (VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION >= 2)
+#include "vtkDijkstraGraphGeodesicPath.h"
+#endif
 #endif
 
 
@@ -77,7 +81,7 @@ int vtkvmtkPolyDataDijkstraDistanceToPoints::RequestData(
   vtkInformationVector *outputVector)
 {
 #if (VTK_MAJOR_VERSION<5) || ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION != 2) && (VTK_MINOR_VERSION<5))
-  vtkErrorMacro(<<"You must have vtk == 5.2 or vt k> =5.5 to use this feature");
+  vtkErrorMacro(<<"You must have vtk == 5.2 or vtk >= 5.5 to use this feature");
     return 1;
 #else
 

--- a/vtkVmtk/Contrib/vtkvmtkPolyDataGeodesicRBFInterpolation.cxx
+++ b/vtkVmtk/Contrib/vtkvmtkPolyDataGeodesicRBFInterpolation.cxx
@@ -39,8 +39,12 @@
 
 #include "vtkvmtkConstants.h"
 
-#if (VTK_MAJOR_VERSION >= 5) && (VTK_MINOR_VERSION >= 2)
+#if (VTK_MAJOR_VERSION > 5)
 #include "vtkDijkstraGraphGeodesicPath.h"
+#else
+#if (VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION >= 2)
+#include "vtkDijkstraGraphGeodesicPath.h"
+#endif
 #endif
 
 
@@ -110,7 +114,7 @@ int vtkvmtkPolyDataGeodesicRBFInterpolation::RequestData(
   vtkInformationVector *outputVector)
 {
 #if (VTK_MAJOR_VERSION<5) || ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION != 2) && (VTK_MINOR_VERSION<5))
-  vtkErrorMacro(<<"You must have vtk == 5.2 or vt k> =5.5 to use this feature");
+  vtkErrorMacro(<<"You must have vtk == 5.2 or vtk >= 5.5 to use this feature");
     return 1;
 #else
 
@@ -179,7 +183,7 @@ int vtkvmtkPolyDataGeodesicRBFInterpolation::RequestData(
   dijkstraAlgo->StopWhenEndReachedOff();
   dijkstraAlgo->UseScalarWeightsOff();
   
-  vtkstd::vector<vtkDoubleArray *> geodesicDistances;
+  std::vector<vtkDoubleArray *> geodesicDistances;
   
   
   //Compute the geodesic distances

--- a/vtkVmtk/Contrib/vtkvmtkSurfaceProjectCellArray.cxx
+++ b/vtkVmtk/Contrib/vtkvmtkSurfaceProjectCellArray.cxx
@@ -108,7 +108,7 @@ int vtkvmtkSurfaceProjectCellArray::RequestData(
     output->GetCellData()->AddArray(projectedArray);
     }
     
-  int numberOfComponents = vtkstd::min(referenceArray->GetNumberOfComponents(), projectedArray->GetNumberOfComponents());
+  int numberOfComponents = std::min(referenceArray->GetNumberOfComponents(), projectedArray->GetNumberOfComponents());
 
   for (int i=0; i<numberOfComponents; i++)
     {


### PR DESCRIPTION
Several fixes in Contrib module have been made for support VTK6 (See #140):
- Fixed `SetInput` -> `SetInputData`
- Fixed checking availability for `vtkDijkstraGraphGeodesicPath`
- Replaced `vtkstd` -> `std`
