### PR TITLE
vmtkimagewriter: changed default value of ApplyTransform (now = 1)

### DIFF
--- a/vmtkScripts/vmtkimagewriter.py
+++ b/vmtkScripts/vmtkimagewriter.py
@@ -30,7 +30,7 @@ class vmtkImageWriter(pypes.pypeScript):
         self.Format = ''
         self.GuessFormat = 1
         self.UseITKIO = 1
-        self.ApplyTransform = 0
+        self.ApplyTransform = 1
         self.OutputFileName = ''
         self.OutputRawFileName = ''
         self.OutputDirectoryName = ''


### PR DESCRIPTION
Changed default value of ApplyTransform (now = 1). In this way the RasToIjkMatrixCoefficients are used if WriteITKIO is used. 
It should be decided the behavior of vmtkimagewriter if ApplyTransform is set to 0: now a warning in vtkvmtkITKImageWriter is launched (ITKWriteVTKImage: rasToIjkMatrix is null) and the output image has "default" values for orientation, origin and spacing (but setting the spacing equal to 1,1,1 is a strange behavior!). I have two suggestions: 1) eliminate  ApplyTransform option (I don't see the utility), 2) Decide a "more useful" default behavior to be added in vmtkimagewriter line 186 (if not self.ApplyTransform ... ) (for example maintaining spacing and origin but not orientation?). 