### PR TITLE
vmtkimagewriter: bug with meta image and ITKIO solved

### DIFF
--- a/vmtkScripts/vmtkimagewriter.py
+++ b/vmtkScripts/vmtkimagewriter.py
@@ -30,7 +30,7 @@ class vmtkImageWriter(pypes.pypeScript):
         self.Format = ''
         self.GuessFormat = 1
         self.UseITKIO = 1
-        self.ApplyTransform = 1
+        self.ApplyTransform = 0
         self.OutputFileName = ''
         self.OutputRawFileName = ''
         self.OutputDirectoryName = ''
@@ -38,7 +38,7 @@ class vmtkImageWriter(pypes.pypeScript):
         self.Image = None
         self.Input = None
       	self.WindowLevel = [1.0, 0.0]
-        self.RasToIjkMatrixCoefficients = [1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]
+        self.RasToIjkMatrixCoefficients = None #[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]
 
         self.SetScriptName('vmtkimagewriter')
         self.SetScriptDoc('write an image to disk')
@@ -184,10 +184,20 @@ class vmtkImageWriter(pypes.pypeScript):
         writer.SetInput(self.Image)
         writer.SetFileName(self.OutputFileName)
         writer.SetUseCompression(1)
-        if self.ApplyTransform and self.RasToIjkMatrixCoefficients:
+        if self.ApplyTransform == 0:
+            origin = self.Image.GetOrigin()
+            spacing = self.Image.GetSpacing()
+            matrix = vtk.vtkMatrix4x4()
+            matrix.DeepCopy((1/spacing[0], 0, 0, - origin[0]/spacing[0], 
+                         0, 1/spacing[1], 0, - origin[1]/spacing[1],
+                         0, 0, 1/spacing[2], - origin[2]/spacing[2],
+                         0, 0, 0, 1)) #LPI convention with correct origin and spacing 
+        else:
+            if self.RasToIjkMatrixCoefficients == None:
+                self.PrintError('Error: no RasToIjkMatrixCoefficients.')
             matrix = vtk.vtkMatrix4x4()
             matrix.DeepCopy(self.RasToIjkMatrixCoefficients)
-            writer.SetRasToIJKMatrix(matrix)
+        writer.SetRasToIJKMatrix(matrix)
         writer.Write()
  
     def Execute(self):

--- a/vmtkScripts/vmtkimagewriter.py
+++ b/vmtkScripts/vmtkimagewriter.py
@@ -30,7 +30,7 @@ class vmtkImageWriter(pypes.pypeScript):
         self.Format = ''
         self.GuessFormat = 1
         self.UseITKIO = 1
-        self.ApplyTransform = 0
+        self.ApplyTransform = 1
         self.OutputFileName = ''
         self.OutputRawFileName = ''
         self.OutputDirectoryName = ''


### PR DESCRIPTION
Now if boolean ApplyTrasform is false (default behaviour), the meta image is automatically transformed in LPI (same behaviour of other formats, default for VTK). Before this commit origin and spacing were 
lost in the output image.

If boolean ApplyTrasform is true, the RasToIjkMatrixCoefficients (default now is None) are required
and the corresponding transform is applied. Before the default value was the identity matrix, but this choice was misleading in my opinion.

Tested on images with different orientations (RAI, RAS, LPI, ASL) and different angles. 

