### PR TITLE
Homebrew dependency tweaks

### DIFF
--- a/distribution/homebrew/vmtk.rb
+++ b/distribution/homebrew/vmtk.rb
@@ -14,6 +14,7 @@ class Vmtk < Formula
   depends_on "cmake" => :build
   depends_on "vtk"
   depends_on "insightToolkit"
+  depends_on :python
   
   def install
     args = std_cmake_args + %W[

--- a/distribution/homebrew/vmtk.rb
+++ b/distribution/homebrew/vmtk.rb
@@ -12,10 +12,9 @@ class Vmtk < Formula
   # end
 
   depends_on "cmake" => :build
-  depends_on "vtk" => "with-python"
-  depends_on "insightToolkit" => :build
-  depends_on :python => :build
-
+  depends_on "vtk"
+  depends_on "insightToolkit"
+  
   def install
     args = std_cmake_args + %W[
       -DBUILD_TESTING=OFF
@@ -38,7 +37,7 @@ class Vmtk < Formula
 
     args << "-DVTK_WRAP_PYTHON=ON"
 
-    args << "-DPYTHON_EXECUTABLE=#{HOMEBREW_PREFIX}/bin/python"
+    args << "-DPYTHON_EXECUTABLE=#{`which python`}"
     args << "-DPYTHON_LIBRARY='#{`python-config --prefix`.chomp}/lib/libpython2.7.dylib'"
     args << "-DPYTHON_INCLUDE_DIR='#{`python-config --prefix`.chomp}/include/python2.7'"
 


### PR DESCRIPTION
In the course of getting VMTK built with homebrew, I changed a few things that you may wish to merge into master

1. VMTK doesn't require that you use the homebrew python (I have successfully built it using anaconda with the amended formula). To this end, I have set PYTHON_EXECUTABLE using `which python`.

2. Python is a run time requirement as well as build time (unless you turn off python wrapping and the Pypes stuff, I guess - but this isn't implemented in the Formula)

3. ITK is a runtime dependancy as well as build time

4. VTK automatically includes python. 

Cheers,
Rupert