### PR TITLE
Update VMTK to be compatible with VTK7

### DIFF
--- a/vtkVmtk/ComputationalGeometry/vtkvmtkMergeCenterlines.cxx
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkMergeCenterlines.cxx
@@ -315,7 +315,11 @@ int vtkvmtkMergeCenterlines::RequestData(vtkInformation *vtkNotUsed(request), vt
   tupleValue[0] = tupleValue[1] = -1;
   for (i=0; i<numberOfMergedCells; i++)
     {
+#if VTK_MAJOR_VERSION < 7
     cellAdditionalEndPointIds->SetTupleValue(i,tupleValue);
+#else
+    cellAdditionalEndPointIds->SetTypedTuple(i, tupleValue);
+#endif
     }
 
   for (i=0; i<blankedGroupIds->GetNumberOfIds(); i++)
@@ -352,9 +356,18 @@ int vtkvmtkMergeCenterlines::RequestData(vtkInformation *vtkNotUsed(request), vt
         groupUniqueCellIds->Delete();
         }
       vtkIdType tupleValue[2];
+#if VTK_MAJOR_VERSION < 7
       cellAdditionalEndPointIds->GetTupleValue(mergedCellId,tupleValue);
+#else
+      cellAdditionalEndPointIds->GetTypedTuple(mergedCellId,tupleValue);
+#endif
       tupleValue[1] = bifurcationPointId;
+#if VTK_MAJOR_VERSION < 7
       cellAdditionalEndPointIds->SetTupleValue(mergedCellId,tupleValue);
+#else
+      cellAdditionalEndPointIds->SetTypedTuple(mergedCellId,tupleValue);
+#endif
+
       }
 
     for (j=0; j<downStreamGroupIds->GetNumberOfIds(); j++)
@@ -373,10 +386,18 @@ int vtkvmtkMergeCenterlines::RequestData(vtkInformation *vtkNotUsed(request), vt
         groupUniqueCellIds->Delete();
         }
       vtkIdType tupleValue[2];
+#if VTK_MAJOR_VERSION < 7
       cellAdditionalEndPointIds->GetTupleValue(mergedCellId,tupleValue);
+#else
+      cellAdditionalEndPointIds->GetTypedTuple(mergedCellId, tupleValue);
+#endif
       tupleValue[0] = bifurcationPointId;
+#if VTK_MAJOR_VERSION < 7
       cellAdditionalEndPointIds->SetTupleValue(mergedCellId,tupleValue);
-      }
+#else
+      cellAdditionalEndPointIds->SetTypedTuple(mergedCellId, tupleValue);
+#endif
+    }
     if (sourcePointId == -1)
       {
       upStreamGroupIds->Delete();
@@ -400,7 +421,11 @@ int vtkvmtkMergeCenterlines::RequestData(vtkInformation *vtkNotUsed(request), vt
     pts = NULL;
     outputLines->GetNextCell(npts,pts);
     vtkIdType tupleValue[2];
+#if VTK_MAJOR_VERSION < 7
     cellAdditionalEndPointIds->GetTupleValue(i,tupleValue);
+#else
+    cellAdditionalEndPointIds->GetTypedTuple(i, tupleValue);
+#endif
     vtkIdType extendedNpts = npts;
     if (tupleValue[0] != -1)
       {

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkPolyBall.h
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkPolyBall.h
@@ -52,6 +52,8 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyBall : public vtkImplici
   // Set / get input poly data.
   vtkSetObjectMacro(Input,vtkPolyData);
   vtkGetObjectMacro(Input,vtkPolyData);
+  void SetInputData(vtkPolyData* input) { SetInput(input); }
+  vtkPolyData* GetInputData() { return GetInput(); }
 
   // Description:
   // Set / get poly ball radius array name.

--- a/vtkVmtk/Contrib/vtkvmtkPolyBallLine2.h
+++ b/vtkVmtk/Contrib/vtkvmtkPolyBallLine2.h
@@ -62,6 +62,8 @@ class VTK_VMTK_CONTRIB_EXPORT vtkvmtkPolyBallLine2 : public vtkImplicitFunction
   // Set / get input poly data.
   virtual void SetInput(vtkPolyData *inp);
   vtkGetObjectMacro(Input,vtkPolyData);
+  void SetInputData(vtkPolyData* input) { SetInput(input); }
+  vtkPolyData* GetInputData() { return GetInput(); }
 
   // Description:
   // Set / get input cell ids used for the function.

--- a/vtkVmtk/DifferentialGeometry/vtkvmtkFEShapeFunctions.cxx
+++ b/vtkVmtk/DifferentialGeometry/vtkvmtkFEShapeFunctions.cxx
@@ -251,9 +251,11 @@ void vtkvmtkFEShapeFunctions::GetInterpolationFunctions(vtkCell* cell, double* p
     case VTK_QUADRATIC_QUAD:
       vtkQuadraticQuad::SafeDownCast(cell)->InterpolationFunctions(pcoords,sf);
       break;
+#if VTK_MAJOR_VERSION < 7
     case VTK_BIQUADRATIC_QUAD:
       vtkBiQuadraticQuad::SafeDownCast(cell)->InterpolationFunctions(pcoords,sf);
       break;
+#endif
     case VTK_TRIANGLE:
       vtkTriangle::SafeDownCast(cell)->InterpolationFunctions(pcoords,sf);
       break;
@@ -302,9 +304,11 @@ void vtkvmtkFEShapeFunctions::GetInterpolationDerivs(vtkCell* cell, double* pcoo
     case VTK_QUADRATIC_QUAD:
       vtkQuadraticQuad::SafeDownCast(cell)->InterpolationDerivs(pcoords,derivs);
       break;
+#if VTK_MAJOR_VERSION < 7
     case VTK_BIQUADRATIC_QUAD:
       vtkBiQuadraticQuad::SafeDownCast(cell)->InterpolationDerivs(pcoords,derivs);
       break;
+#endif
     case VTK_TRIANGLE:
       vtkTriangle::SafeDownCast(cell)->InterpolationDerivs(pcoords,derivs);
       break;

--- a/vtkVmtk/Misc/vtkvmtkCurvedMPRImageFilter.cxx
+++ b/vtkVmtk/Misc/vtkvmtkCurvedMPRImageFilter.cxx
@@ -100,12 +100,21 @@ int vtkvmtkCurvedMPRImageFilter::RequestInformation (
       outputImage->SetWholeExtent(outputExtent);
       outputImage->SetUpdateExtent(outputExtent);
       outputImage->AllocateScalars();
-#else
+#elif (VTK_MAJOR_VERSION < 7)
       this->UpdateInformation();
       vtkStreamingDemandDrivenPipeline::SetUpdateExtent(outInfo, outputExtent);
       this->Update();
       outputImage->AllocateScalars(outInfo);
+#else
+      if (this->GetOutputInformation(0))
+        {
+        this->GetOutputInformation(0)->Set(
+          vtkStreamingDemandDrivenPipeline::UPDATE_EXTENT(),
+        this->GetOutputInformation(0)->Get(
+          vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT()), 6);
+        }
 #endif
+
       }
     if ( inputImage == NULL)
       {
@@ -232,11 +241,19 @@ int vtkvmtkCurvedMPRImageFilter::RequestData(
       outputImage->SetWholeExtent(outputExtent);
       outputImage->SetUpdateExtent(outputExtent);
       outputImage->AllocateScalars();
-#else
+#elif (VTK_MAJOR_VERSION < 7)
       this->UpdateInformation();
       vtkStreamingDemandDrivenPipeline::SetUpdateExtent(outInfo, outputExtent);
       this->Update();
       outputImage->AllocateScalars(outInfo);
+#else
+      if (this->GetOutputInformation(0))
+        {
+        this->GetOutputInformation(0)->Set(
+          vtkStreamingDemandDrivenPipeline::UPDATE_EXTENT(),
+          this->GetOutputInformation(0)->Get(
+          vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT()), 6);
+        }
 #endif
       }
    
@@ -309,11 +326,19 @@ int vtkvmtkCurvedMPRImageFilter::RequestData(
   outputImage->SetWholeExtent(outExtent);
   outputImage->SetUpdateExtent(outExtent);
   outputImage->AllocateScalars();
-#else
+#elif (VTK_MAJOR_VERSION < 7)
   this->UpdateInformation();
   vtkStreamingDemandDrivenPipeline::SetUpdateExtent(outInfo, outExtent);
   this->Update();  
   outputImage->AllocateScalars(outInfo);
+#else
+if (this->GetOutputInformation(0))
+  {
+  this->GetOutputInformation(0)->Set(
+    vtkStreamingDemandDrivenPipeline::UPDATE_EXTENT(),
+    this->GetOutputInformation(0)->Get(
+    vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT()), 6);
+  }
 #endif
 
   vtkDataArray* frenetTangentArray = this->Centerline->GetPointData()->GetArray(this->FrenetTangentArrayName); 

--- a/vtkVmtk/Misc/vtkvmtkPolyDataNetworkExtraction.cxx
+++ b/vtkVmtk/Misc/vtkvmtkPolyDataNetworkExtraction.cxx
@@ -174,7 +174,11 @@ void vtkvmtkPolyDataNetworkExtraction::InsertInEdgeTable(vtkIdTypeArray* edgeTab
   vtkIdType edge[2];
   edge[0] = pointId0;
   edge[1] = pointId1;
+#if (VTK_MAJOR_VERSION < 7)
   edgeTable->InsertNextTupleValue(edge);
+#else
+  edgeTable->InsertNextTypedTuple(edge);
+#endif
 }
 
 bool vtkvmtkPolyDataNetworkExtraction::InsertUniqueInEdgeTable(vtkIdTypeArray* edgeTable, vtkIdType pointId0, vtkIdType pointId1)
@@ -186,20 +190,33 @@ bool vtkvmtkPolyDataNetworkExtraction::InsertUniqueInEdgeTable(vtkIdTypeArray* e
   for (i=0; i<edgeTable->GetNumberOfTuples(); i++)
     {
     vtkIdType currentEdge[2];
+#if (VTK_MAJOR_VERSION < 7)
     edgeTable->GetTupleValue(i,currentEdge);
+#else
+    edgeTable->GetTypedTuple(i, currentEdge);
+#endif
     if (currentEdge[0]==edge[0] && currentEdge[1]==edge[1])
       {
       return false;
       }
     }
 
+#if (VTK_MAJOR_VERSION < 7)
   edgeTable->InsertNextTupleValue(edge);
+#else
+  edgeTable->InsertNextTypedTuple(edge);
+#endif
+
   return true;
 }
 
 void vtkvmtkPolyDataNetworkExtraction::GetFromEdgeTable(vtkIdTypeArray* edgeTable, vtkIdType position, vtkIdType edge[2])
 {
+#if (VTK_MAJOR_VERSION < 7)
   edgeTable->GetTupleValue(position,edge);
+#else
+  edgeTable->GetTypedTuple(position, edge);
+#endif
 }
 
 void vtkvmtkPolyDataNetworkExtraction::UpdateEdgeTableCollectionReal(vtkPolyData* model,vtkPolyDataCollection* profiles,vtkCollection* edgeTables)
@@ -1295,8 +1312,12 @@ void vtkvmtkPolyDataNetworkExtraction::BuildSegment(vtkPoints* segmentPoints, vt
   segmentTopologyArray->SetName(TopologyArrayName);
   segmentTopologyArray->SetNumberOfComponents(2);
 
+#if (VTK_MAJOR_VERSION < 7)
   segmentTopologyArray->InsertNextTupleValue(segmentTopology);
-  
+#else
+  segmentTopologyArray->InsertNextTypedTuple(segmentTopology);
+#endif
+
   // start
   if (segmentTopology[0] > 0)
     {
@@ -1540,8 +1561,13 @@ void vtkvmtkPolyDataNetworkExtraction::JoinSegments (vtkPolyData* segment0, vtkP
   vtkIdType segmentTopology0[2];
   vtkIdType segmentTopology1[2];
 
-  segment0TopologyArray->GetTupleValue(0,segmentTopology0);
-  segment1TopologyArray->GetTupleValue(0,segmentTopology1);
+#if (VTK_MAJOR_VERSION < 7)
+  segment0TopologyArray->GetTupleValue(0, segmentTopology0);
+  segment1TopologyArray->GetTupleValue(0, segmentTopology1);
+#else
+  segment0TopologyArray->GetTypedTuple(0, segmentTopology0);
+  segment1TopologyArray->GetTypedTuple(0, segmentTopology1);
+#endif
   
   vtkIdType segmentTopology[2];
     
@@ -1584,7 +1610,11 @@ void vtkvmtkPolyDataNetworkExtraction::JoinSegments (vtkPolyData* segment0, vtkP
       }
     }
  
+#if (VTK_MAJOR_VERSION < 7)
   topologyArray->InsertNextTupleValue(segmentTopology);
+#else
+  topologyArray->InsertNextTypedTuple(segmentTopology);
+#endif
   
   vtkCellArray* segmentCell = vtkCellArray::New();
   segmentCell->InsertNextCell(segmentPoints->GetNumberOfPoints());
@@ -1626,7 +1656,11 @@ void vtkvmtkPolyDataNetworkExtraction::RemoveDegenerateBifurcations(vtkPolyDataC
 //    vtkDoubleArray* radiusArray = vtkDoubleArray::SafeDownCast(segment->GetPointData()->GetArray(RadiusArrayName));
     vtkIdTypeArray* topologyArray = vtkIdTypeArray::SafeDownCast(segment->GetCellData()->GetArray(TopologyArrayName));
     vtkIdType topology[2];
+#if (VTK_MAJOR_VERSION < 7)
     topologyArray->GetTupleValue(0,topology);
+#else
+    topologyArray->GetTypedTuple(0, topology);
+#endif
     vtkIdType bifurcation0 = topology[0];
     if (bifurcation0 > 0)
       {
@@ -1670,7 +1704,11 @@ void vtkvmtkPolyDataNetworkExtraction::RemoveDegenerateBifurcations(vtkPolyDataC
 //      vtkDoubleArray* radiusArray = vtkDoubleArray::SafeDownCast(currentSegment->GetPointData()->GetArray(RadiusArrayName));
       vtkIdTypeArray* topologyArray = vtkIdTypeArray::SafeDownCast(currentSegment->GetCellData()->GetArray(TopologyArrayName));
       vtkIdType topology[2];
+#if (VTK_MAJOR_VERSION < 7)
       topologyArray->GetTupleValue(0,topology);
+#else
+      topologyArray->GetTypedTuple(0,topology);
+#endif
       if (!segment0)
         {
         degenerateId = topology[0];
@@ -1729,7 +1767,11 @@ void vtkvmtkPolyDataNetworkExtraction::RemoveDegenerateBifurcations(vtkPolyDataC
 //    vtkDoubleArray* radiusArray = vtkDoubleArray::SafeDownCast(currentSegment->GetPointData()->GetArray(RadiusArrayName));
     vtkIdTypeArray* topologyArray = vtkIdTypeArray::SafeDownCast(currentSegment->GetCellData()->GetArray(TopologyArrayName));
     vtkIdType topology[2];
-    topologyArray->GetTupleValue(0,topology);
+#if (VTK_MAJOR_VERSION < 7)
+    topologyArray->GetTupleValue(0, topology);
+#else
+    topologyArray->GetTypedTuple(0, topology);
+#endif
     scalar0 = topology[0];
     scalar1 = topology[1];
     if (scalar0 > 0)
@@ -1742,7 +1784,11 @@ void vtkvmtkPolyDataNetworkExtraction::RemoveDegenerateBifurcations(vtkPolyDataC
       position1=realBifurcations->InsertUniqueId(scalar1);
       topology[1] = position1;
       }
+#if (VTK_MAJOR_VERSION < 7)
     topologyArray->InsertTupleValue(0,topology);
+#else
+    topologyArray->InsertTypedTuple(0,topology);
+#endif
     }
 
   realBifurcations->Delete();
@@ -1809,8 +1855,13 @@ void vtkvmtkPolyDataNetworkExtraction::GlobalIteration(vtkPolyData* model, vtkPo
     {
     vtkIdType topology[2];
     vtkIdTypeArray* segmentTopologyArray = vtkIdTypeArray::SafeDownCast(segments->GetNextItem()->GetCellData()->GetArray(TopologyArrayName));
-    segmentTopologyArray->GetTupleValue(0,topology);
+#if (VTK_MAJOR_VERSION < 7)
+    segmentTopologyArray->GetTupleValue(0, topology);
     topologyArray->InsertNextTupleValue(topology);
+#else
+    segmentTopologyArray->GetTypedTuple(0, topology);
+    topologyArray->InsertNextTypedTuple(topology);
+#endif
     }
 
   vtkAppendPolyData* segmentsAppended = vtkAppendPolyData::New();
@@ -1880,7 +1931,11 @@ void vtkvmtkPolyDataNetworkExtraction::Graph(vtkPolyData* network, vtkPolyData* 
     {
     vtkCell* cell = network->GetCell(i);
     vtkIdType topology[2];
-    topologyArray->GetTupleValue(i,topology);
+#if (VTK_MAJOR_VERSION < 7)
+    topologyArray->GetTupleValue(i, topology);
+#else
+    topologyArray->GetTypedTuple(i, topology);
+#endif
 
     vtkIdType numberOfCellPoints = cell->GetNumberOfPoints();
     double meanRadius = 0.0;

--- a/vtkVmtk/Misc/vtkvmtkRBFInterpolation.cxx
+++ b/vtkVmtk/Misc/vtkvmtkRBFInterpolation.cxx
@@ -23,6 +23,7 @@ Version:   $Revision: 1.2 $
 #include "vtkPointData.h"
 #include "vtkMath.h"
 #include "vtkObjectFactory.h"
+#include "vtkVersion.h"
 
 
 vtkStandardNewMacro(vtkvmtkRBFInterpolation);
@@ -182,7 +183,11 @@ void vtkvmtkRBFInterpolation::EvaluateGradient(double x[3], double n[3])
   vtkWarningMacro("RBF gradient computation not implemented.");
 }
 
+#if (VTK_MAJOR_VERSION < 7)
 unsigned long vtkvmtkRBFInterpolation::GetMTime()
+#else
+vtkMTimeType vtkvmtkRBFInterpolation::GetMTime()
+#endif
 {
   unsigned long mTime=this->Superclass::GetMTime();
   unsigned long sourceMTime;

--- a/vtkVmtk/Misc/vtkvmtkRBFInterpolation.h
+++ b/vtkVmtk/Misc/vtkvmtkRBFInterpolation.h
@@ -29,6 +29,7 @@ Version:   $Revision: 1.3 $
 #include "vtkPolyData.h"
 #include "vtkDoubleArray.h"
 #include "vtkvmtkWin32Header.h"
+#include "vtkVersion.h"
 
 class VTK_VMTK_MISC_EXPORT vtkvmtkRBFInterpolation : public vtkImplicitFunction
 {
@@ -73,7 +74,11 @@ class VTK_VMTK_MISC_EXPORT vtkvmtkRBFInterpolation : public vtkImplicitFunction
   };
 //ETX
 
+#if (VTK_MAJOR_VERSION < 7)
   unsigned long GetMTime();
+#else
+  vtkMTimeType GetMTime();
+#endif
 
   protected:
   vtkvmtkRBFInterpolation();

--- a/vtkVmtk/Utilities/vtkvmtkITK/vtkvmtkITKArchetypeImageSeriesScalarReader.cxx
+++ b/vtkVmtk/Utilities/vtkvmtkITK/vtkvmtkITKArchetypeImageSeriesScalarReader.cxx
@@ -17,7 +17,11 @@
 // VTK includes
 #include <vtkCommand.h>
 #include <vtkDataArray.h>
+#if VTK_MAJOR_VERSION < 7
 #include <vtkDataArrayTemplate.h>
+#else
+#include <vtkAOSDataArrayTemplate.h>
+#endif
 #include <vtkImageData.h>
 #include <vtkInformation.h>
 #include <vtkInformationVector.h>
@@ -34,6 +38,7 @@ vtkStandardNewMacro(vtkvmtkITKArchetypeImageSeriesScalarReader);
 
 namespace {
 
+#if VTK_MAJOR_VERSION < 7
 template <class T>
 vtkDataArrayTemplate<T>* DownCast(vtkAbstractArray* a)
 {
@@ -43,7 +48,17 @@ vtkDataArrayTemplate<T>* DownCast(vtkAbstractArray* a)
   return vtkDataArrayTemplate<T>::FastDownCast(a);
 #endif
 }
+#else
+template <class T>
+vtkAOSDataArrayTemplate<T>* DownCast(vtkAbstractArray* a)
+{
+  return vtkAOSDataArrayTemplate<T>::FastDownCast(a);
 
+
+
+
+}
+#endif
 };
 
 //----------------------------------------------------------------------------
@@ -95,6 +110,7 @@ int vtkvmtkITKArchetypeImageSeriesScalarReader::RequestData(
 #endif
 
 /// SCALAR MACRO
+#if VTK_MAJOR_VERSION < 7
 #define vtkITKExecuteDataFromSeries(typeN, type) \
     case typeN: \
     {\
@@ -133,7 +149,48 @@ int vtkvmtkITKArchetypeImageSeriesScalarReader::RequestData(
       PixelContainer##typeN->ContainerManageMemoryOff();\
     }\
     break
+#else
+#define vtkITKExecuteDataFromSeries(typeN, type) \
+    case typeN: \
+    {\
+      typedef itk::Image<type,3> image##typeN;\
+      typedef itk::ImageSource<image##typeN> FilterType; \
+      FilterType::Pointer filter; \
+      itk::ImageSeriesReader<image##typeN>::Pointer reader##typeN = \
+          itk::ImageSeriesReader<image##typeN>::New(); \
+          itk::CStyleCommand::Pointer pcl=itk::CStyleCommand::New(); \
+          pcl->SetCallback((itk::CStyleCommand::FunctionPointer)&ReadProgressCallback); \
+          pcl->SetClientData(this); \
+          reader##typeN->AddObserver(itk::ProgressEvent(),pcl); \
+      reader##typeN->SetFileNames(this->FileNames); \
+      reader##typeN->ReleaseDataFlagOn(); \
+      if (this->UseNativeCoordinateOrientation) \
+        { \
+        filter = reader##typeN; \
+        } \
+      else \
+        { \
+        itk::OrientImageFilter<image##typeN,image##typeN>::Pointer orient##typeN = \
+            itk::OrientImageFilter<image##typeN,image##typeN>::New(); \
+        if (this->Debug) {orient##typeN->DebugOn();} \
+        orient##typeN->SetInput(reader##typeN->GetOutput()); \
+        orient##typeN->UseImageDirectionOn(); \
+        orient##typeN->SetDesiredCoordinateOrientation(this->DesiredCoordinateOrientation); \
+        filter = orient##typeN; \
+        }\
+      filter->UpdateLargestPossibleRegion(); \
+      itk::ImportImageContainer<itk::SizeValueType, type>::Pointer PixelContainer##typeN;\
+      PixelContainer##typeN = filter->GetOutput()->GetPixelContainer();\
+      void *ptr = static_cast<void *> (PixelContainer##typeN->GetBufferPointer());\
+      DownCast<type>(data->GetPointData()->GetScalars())                \
+        ->SetVoidArray(ptr, PixelContainer##typeN->Size(), 0,\
+                       vtkAOSDataArrayTemplate<type>::VTK_DATA_ARRAY_DELETE);\
+      PixelContainer##typeN->ContainerManageMemoryOff();\
+    }\
+    break
+#endif
 
+#if VTK_MAJOR_VERSION < 7
 #define vtkITKExecuteDataFromFile(typeN, type) \
     case typeN: \
     {\
@@ -167,6 +224,41 @@ int vtkvmtkITKArchetypeImageSeriesScalarReader::RequestData(
       PixelContainer2##typeN->ContainerManageMemoryOff();\
     }\
     break
+#else
+#define vtkITKExecuteDataFromFile(typeN, type) \
+    case typeN: \
+    {\
+      typedef itk::Image<type,3> image2##typeN;\
+      typedef itk::ImageSource<image2##typeN> FilterType; \
+      FilterType::Pointer filter; \
+      itk::ImageFileReader<image2##typeN>::Pointer reader2##typeN = \
+            itk::ImageFileReader<image2##typeN>::New(); \
+      reader2##typeN->SetFileName(this->FileNames[0].c_str()); \
+      if (this->UseNativeCoordinateOrientation) \
+        { \
+        filter = reader2##typeN; \
+        } \
+      else \
+        { \
+        itk::OrientImageFilter<image2##typeN,image2##typeN>::Pointer orient2##typeN = \
+              itk::OrientImageFilter<image2##typeN,image2##typeN>::New(); \
+        if (this->Debug) {orient2##typeN->DebugOn();} \
+        orient2##typeN->SetInput(reader2##typeN->GetOutput()); \
+        orient2##typeN->UseImageDirectionOn(); \
+        orient2##typeN->SetDesiredCoordinateOrientation(this->DesiredCoordinateOrientation); \
+        filter = orient2##typeN; \
+        } \
+      filter->UpdateLargestPossibleRegion();\
+      itk::ImportImageContainer<itk::SizeValueType, type>::Pointer PixelContainer2##typeN;\
+      PixelContainer2##typeN = filter->GetOutput()->GetPixelContainer();\
+      void *ptr = static_cast<void *> (PixelContainer2##typeN->GetBufferPointer());\
+      DownCast<type>(data->GetPointData()->GetScalars())                \
+        ->SetVoidArray(ptr, PixelContainer2##typeN->Size(), 0,\
+                       vtkAOSDataArrayTemplate<type>::VTK_DATA_ARRAY_DELETE);\
+      PixelContainer2##typeN->ContainerManageMemoryOff();\
+    }\
+    break
+#endif
   /// END SCALAR MACRO
 
   // If there is only one file in the series, just use an image file reader

--- a/vtkVmtk/Utilities/vtkvmtkITK/vtkvmtkITKImageWriter.cxx
+++ b/vtkVmtk/Utilities/vtkvmtkITK/vtkvmtkITKImageWriter.cxx
@@ -331,11 +331,20 @@ void vtkvmtkITKImageWriter::Write()
 #if (VTK_MAJOR_VERSION <= 5)
   inputImage->UpdateInformation();
   inputImage->SetUpdateExtent(inputImage->GetWholeExtent());
-#else
+#elif (VTK_MAJOR_VERSION < 7)
   this->UpdateInformation();
   this->SetUpdateExtent(this->GetOutputInformation(0)->Get(
                         vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT()));
+#else
+  if (this->GetOutputInformation(0))
+    {
+    this->GetOutputInformation(0)->Set(
+      vtkStreamingDemandDrivenPipeline::UPDATE_EXTENT(),
+    this->GetOutputInformation(0)->Get(
+      vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT()), 6);
+    }
 #endif
+
   int inputDataType =
     pointData->GetScalars() ? pointData->GetScalars()->GetDataType() :
     pointData->GetTensors() ? pointData->GetTensors()->GetDataType() :
@@ -503,7 +512,11 @@ void vtkvmtkITKImageWriter::Write()
         float outValue[6];
         for(int i=0; i<out->GetNumberOfTuples(); i++)
           {
+#if (VTK_MAJOR_VERSION < 7)
           in->GetTupleValue(i, inValue);
+#else
+          in->GetTypedTuple(i, inValue);
+#endif
           //ITK expect tensors saved in upper-triangular format
           outValue[0] = inValue[0];
           outValue[1] = inValue[1];


### PR DESCRIPTION
Slicer4 uses VTK7 and therefore VMTK had to be updated to support VTK7, too.

All the changes should be backward-compatible, so VMTK works the same way for older VTK versions.

Python scripts have not been updated for VTK7. There should have been a lot of modifications because of SetInput->SetInputData changes. It is doable, see example below, I just did not need it and if backward compatibility is not needed then the changes would be much simpler.

    if vtk.VTK_MAJOR_VERSION <= 5:
      somefilter.SetInput(self.brush)
    else:
      somefilter.SetInputData(self.brush)