### PR TITLE
Added opacity function for vmtkimagemipviewer.py

### DIFF
--- a/vmtkScripts/vmtkimagemipviewer.py
+++ b/vmtkScripts/vmtkimagemipviewer.py
@@ -110,15 +110,13 @@ class vmtkImageMIPViewer(pypes.pypeScript):
                 opacityFunction.AddPoint(scalarRange[0] + float(scalarRange[1] - scalarRange[0]) * self.Opacity[0], 1.0)
                 opacityFunction.AddPoint(scalarRange[1] + float(scalarRange[1] - scalarRange[0]) * self.Opacity[1], 0.0)
                 opacityFunction.AddPoint(scalarRange[0], 0.0)
-        else:
-            opacityFunction.AddPoint(scalarRange[0], 0.0)
-            opacityFunction.AddPoint(scalarRange[0], 1.0)
 
         volumeProperty = vtk.vtkVolumeProperty()
         volumeProperty.ShadeOn()
         volumeProperty.SetInterpolationTypeToLinear()
         volumeProperty.SetColor(colorTransferFunction)
-        volumeProperty.SetScalarOpacity(opacityFunction)
+        if self.Opacity is not None:
+            volumeProperty.SetScalarOpacity(opacityFunction)
 
         self.Volume = vtk.vtkVolume()
         self.Volume.SetMapper(volumeMapper)

--- a/vmtkScripts/vmtkimagemipviewer.py
+++ b/vmtkScripts/vmtkimagemipviewer.py
@@ -95,21 +95,13 @@ class vmtkImageMIPViewer(pypes.pypeScript):
             volumeMapper.SetSampleDistance(self.SampleDistance)
 
         opacityFunction = vtk.vtkPiecewiseFunction()
-
-        if self.Opacity[0] < 0.3 and self.Opacity[1] < 0.3:
-            self.PrintLog("Warning: opacity < 0.3; image likely not invisible.")
+        imageRange = self.Image.GetScalarRange()
 
         if self.Opacity is not None:
-            if self.Opacity[0] > self.Opacity[1]:
-                opacityFunction.AddPoint(scalarRange[0], 0.0)
-                opacityFunction.AddPoint(scalarRange[0] + float(scalarRange[1] - scalarRange[0]) * self.Opacity[0], 0.0)
-                opacityFunction.AddPoint(scalarRange[1] + float(scalarRange[1] - scalarRange[0]) * self.Opacity[1], 1.0)
-                opacityFunction.AddPoint(scalarRange[0], 1.0)
-            else:
-                opacityFunction.AddPoint(scalarRange[0], 1.0)
-                opacityFunction.AddPoint(scalarRange[0] + float(scalarRange[1] - scalarRange[0]) * self.Opacity[0], 1.0)
-                opacityFunction.AddPoint(scalarRange[1] + float(scalarRange[1] - scalarRange[0]) * self.Opacity[1], 0.0)
-                opacityFunction.AddPoint(scalarRange[0], 0.0)
+            opacityFunction.AddPoint(imageRange[0], 0)
+            opacityFunction.AddPoint(scalarRange[0], self.Opacity[0])
+            opacityFunction.AddPoint(scalarRange[0], self.Opacity[1])
+            opacityFunction.AddPoint(imageRange[1], 1)
 
         volumeProperty = vtk.vtkVolumeProperty()
         volumeProperty.ShadeOn()

--- a/vmtkScripts/vmtkimagemipviewer.py
+++ b/vmtkScripts/vmtkimagemipviewer.py
@@ -22,8 +22,8 @@ import pypes
 
 vmtkimagemipviewer = 'vmtkImageMIPViewer'
 
-class vmtkImageMIPViewer(pypes.pypeScript):
 
+class vmtkImageMIPViewer(pypes.pypeScript):
     def __init__(self):
 
         pypes.pypeScript.__init__(self)
@@ -36,25 +36,28 @@ class vmtkImageMIPViewer(pypes.pypeScript):
 
         self.SampleDistance = 1.0
         self.AutoSampleDistance = 1
-        
+
         self.WindowLevel = [0.0, 0.0]
+        self.Opacity = None
 
         self.Volume = None
 
         self.SetScriptName('vmtkimagemipviewer')
         self.SetScriptDoc('display a 3D image')
         self.SetInputMembers([
-            ['Image','i','vtkImageData',1,'','the input image','vmtkimagereader'],
-            ['ArrayName','array','str',1,'','name of the array to display'],
-            ['vmtkRenderer','renderer','vmtkRenderer',1,'','external renderer'],
-            ['SampleDistance','sampledistance','float',1,'(0.0,)','the distance at sample projections are generated'],
-            ['AutoSampleDistance','autosampledistance','bool',1,'','toggle automatic sample distance'],
-            ['WindowLevel','windowlevel','float',2,'','the window/level for generating the rendering'],
-            ['Display','display','bool',1,'','toggle rendering']
-            ])
+            ['Image', 'i', 'vtkImageData', 1, '', 'the input image', 'vmtkimagereader'],
+            ['ArrayName', 'array', 'str', 1, '', 'name of the array to display'],
+            ['vmtkRenderer', 'renderer', 'vmtkRenderer', 1, '', 'external renderer'],
+            ['SampleDistance', 'sampledistance', 'float', 1, '(0.0,)',
+             'the distance at sample projections are generated'],
+            ['AutoSampleDistance', 'autosampledistance', 'bool', 1, '', 'toggle automatic sample distance'],
+            ['WindowLevel', 'windowlevel', 'float', 2, '', 'the window/level for generating the rendering'],
+            ['Opacity', 'opacity', 'float', 2, '', 'the opacity range is defined from 0 (transparent) to 1 (opaque)'],
+            ['Display', 'display', 'bool', 1, '', 'toggle rendering']
+        ])
         self.SetOutputMembers([
-            ['Image','o','vtkImageData',1,'','the output image','vmtkimagewriter']
-            ])
+            ['Image', 'o', 'vtkImageData', 1, '', 'the output image', 'vmtkimagewriter']
+        ])
 
     def BuildView(self):
 
@@ -63,7 +66,7 @@ class vmtkImageMIPViewer(pypes.pypeScript):
             self.vmtkRenderer.Initialize()
             self.OwnRenderer = 1
 
-        self.vmtkRenderer.RegisterScript(self) 
+        self.vmtkRenderer.RegisterScript(self)
 
         if self.Volume:
             self.vmtkRenderer.Renderer.RemoveVolume(self.Volume)
@@ -74,7 +77,8 @@ class vmtkImageMIPViewer(pypes.pypeScript):
         scalarRange = [0.0, 0.0]
 
         if self.WindowLevel[0] > 0.0:
-            scalarRange = [self.WindowLevel[1] - self.WindowLevel[0]/2.0, self.WindowLevel[1] + self.WindowLevel[0]/2.0]
+            scalarRange = [self.WindowLevel[1] - self.WindowLevel[0] / 2.0,
+                           self.WindowLevel[1] + self.WindowLevel[0] / 2.0]
         else:
             scalarRange = self.Image.GetScalarRange()
 
@@ -89,16 +93,37 @@ class vmtkImageMIPViewer(pypes.pypeScript):
             volumeMapper.AutoAdjustSampleDistancesOn()
         else:
             volumeMapper.SetSampleDistance(self.SampleDistance)
-        
+
+        opacityFunction = vtk.vtkPiecewiseFunction()
+
+        if self.Opacity[0] < 0.3 and self.Opacity[1] < 0.3:
+            self.PrintLog("Warning: opacity < 0.3; image likely not invisible.")
+
+        if self.Opacity is not None:
+            if self.Opacity[0] > self.Opacity[1]:
+                opacityFunction.AddPoint(scalarRange[0], 0.0)
+                opacityFunction.AddPoint(scalarRange[0] + float(scalarRange[1] - scalarRange[0]) * self.Opacity[0], 0.0)
+                opacityFunction.AddPoint(scalarRange[1] + float(scalarRange[1] - scalarRange[0]) * self.Opacity[1], 1.0)
+                opacityFunction.AddPoint(scalarRange[0], 1.0)
+            else:
+                opacityFunction.AddPoint(scalarRange[0], 1.0)
+                opacityFunction.AddPoint(scalarRange[0] + float(scalarRange[1] - scalarRange[0]) * self.Opacity[0], 1.0)
+                opacityFunction.AddPoint(scalarRange[1] + float(scalarRange[1] - scalarRange[0]) * self.Opacity[1], 0.0)
+                opacityFunction.AddPoint(scalarRange[0], 0.0)
+        else:
+            opacityFunction.AddPoint(scalarRange[0], 0.0)
+            opacityFunction.AddPoint(scalarRange[0], 1.0)
+
         volumeProperty = vtk.vtkVolumeProperty()
         volumeProperty.ShadeOn()
         volumeProperty.SetInterpolationTypeToLinear()
         volumeProperty.SetColor(colorTransferFunction)
-        
+        volumeProperty.SetScalarOpacity(opacityFunction)
+
         self.Volume = vtk.vtkVolume()
         self.Volume.SetMapper(volumeMapper)
         self.Volume.SetProperty(volumeProperty)
-      
+
         self.vmtkRenderer.Renderer.AddVolume(self.Volume)
 
         if (self.Display == 1):
@@ -111,10 +136,11 @@ class vmtkImageMIPViewer(pypes.pypeScript):
 
         if (self.Image == None) & (self.Display == 1):
             self.PrintError('Error: no Image.')
- 
+
         self.BuildView()
-       
-if __name__=='__main__':
+
+
+if __name__ == '__main__':
     main = pypes.pypeMain()
     main.Arguments = sys.argv
     main.Execute()


### PR DESCRIPTION
Added opacity function to `vmtkimagemipviewer.py`.
Usage: add ` -opacity 0 0.5` for a linear increasing opacity map.
            add ` -opacity 0.5 0.5` for a continuous opacity of 0.5
Useful to visualize lines within the mip viewer; see attached screenshot.

The opacity is applied after the window level.
The minimum of the image also receives a opacity of 0
The maximum of the image also receives a opacity of 1

Optimizations could be added depending on the desired user input / interface.
![2017-01-05 17_39_39-vmtk - the vascular modeling toolkit](https://cloud.githubusercontent.com/assets/981436/21688848/9c496a94-d36e-11e6-8238-2b3535e3a64a.png)
_screenshot: decreased opacity enables visualisation of points within the MIP_