### PR TITLE
fixed memory leak referenced in vmtk/vmtk issue #185

### DIFF
--- a/vtkVmtk/DifferentialGeometry/vtkvmtkPolyDataSurfaceRemeshing.cxx
+++ b/vtkVmtk/DifferentialGeometry/vtkvmtkPolyDataSurfaceRemeshing.cxx
@@ -684,6 +684,7 @@ int vtkvmtkPolyDataSurfaceRemeshing::IsPointOnEntityBoundary(vtkIdType pointId)
     return 1;
     }
 
+  ptCells->Delete();
   return 0;
 }
 


### PR DESCRIPTION
Simple one line memory leak fix in vtkvmtkPolyDataSurfaceRemeshing.cxx

This PR is in reference to Issue #185 . 

Thank you to @normanius for identifying the problem and proposing the solution. 

@lantiga , please merge at your convenience. 