### PR TITLE
fixed improper string comparisons referenced in vmtk/vmtk issue #183

### DIFF
--- a/vmtkScripts/vmtkpathlineanimator.py
+++ b/vmtkScripts/vmtkpathlineanimator.py
@@ -187,7 +187,7 @@ class vmtkPathLineAnimator(pypes.pypeScript):
         if (self.ArrayMax == None and self.ArrayName == "Velocity"):
             self.ArrayMax = round(self.Traces.GetPointData().GetArray('Speed').GetRange()[1],0)
         
-        if self.Method is 'particles':
+        if self.Method == 'particles':
             particleTime = minTime
             imageNumber = 0
             while particleTime <= maxTime:
@@ -220,7 +220,7 @@ class vmtkPathLineAnimator(pypes.pypeScript):
                 currentTime+=self.TimeStep
                 imageNumber+=1
 
-        elif self.Method is 'streaklines':
+        elif self.Method == 'streaklines':
             particleTime = minTime
             imageNumber = 0
             while particleTime <= maxTime:

--- a/vmtkScripts/vmtksurfacesmoothing.py
+++ b/vmtkScripts/vmtksurfacesmoothing.py
@@ -60,7 +60,7 @@ class vmtkSurfaceSmoothing(pypes.pypeScript):
 
         smoothingFilter = None
 
-        if self.Method is 'taubin':
+        if self.Method == 'taubin':
             smoothingFilter = vtk.vtkWindowedSincPolyDataFilter()
             smoothingFilter.SetInputData(self.Surface)
             smoothingFilter.SetNumberOfIterations(self.NumberOfIterations)
@@ -68,7 +68,7 @@ class vmtkSurfaceSmoothing(pypes.pypeScript):
             smoothingFilter.SetBoundarySmoothing(self.BoundarySmoothing)
             smoothingFilter.SetNormalizeCoordinates(self.NormalizeCoordinates)
             smoothingFilter.Update()
-        elif self.Method is 'laplace':
+        elif self.Method == 'laplace':
             smoothingFilter = vtk.vtkSmoothPolyDataFilter()
             smoothingFilter.SetInputData(self.Surface)
             smoothingFilter.SetNumberOfIterations(self.NumberOfIterations)


### PR DESCRIPTION
Fixed improper string comparison referenced in Issue #183 

Also fixed bug in vmtkpathlineanimator.py

Thank you to @normanius for identifying the problem and proposing a solution

@lantiga please merge at your convenience. 