### PR TITLE
Compatibility with VTK 8.0

### DIFF
--- a/vtkVmtk/Utilities/vtkvmtkITK/vtkvmtkITKArchetypeImageSeriesScalarReader.cxx
+++ b/vtkVmtk/Utilities/vtkvmtkITK/vtkvmtkITKArchetypeImageSeriesScalarReader.cxx
@@ -17,7 +17,7 @@
 // VTK includes
 #include <vtkCommand.h>
 #include <vtkDataArray.h>
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
 #include <vtkAOSDataArrayTemplate.h>
 #else
 #include <vtkDataArrayTemplate.h>
@@ -38,7 +38,7 @@ vtkStandardNewMacro(vtkvmtkITKArchetypeImageSeriesScalarReader);
 
 namespace {
 
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
   template <class T>
   vtkAOSDataArrayTemplate<T>* DownCast(vtkAbstractArray* a)
   {
@@ -106,7 +106,7 @@ int vtkvmtkITKArchetypeImageSeriesScalarReader::RequestData(
 #endif
 
 /// SCALAR MACRO
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
 #define vtkITKExecuteDataFromSeries(typeN, type) \
     case typeN: \
     {\
@@ -186,7 +186,7 @@ int vtkvmtkITKArchetypeImageSeriesScalarReader::RequestData(
     break
 #endif
 
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
 #define vtkITKExecuteDataFromFile(typeN, type) \
     case typeN: \
     {\

--- a/vtkVmtk/Utilities/vtkvmtkITK/vtkvmtkITKImageWriter.cxx
+++ b/vtkVmtk/Utilities/vtkvmtkITK/vtkvmtkITKImageWriter.cxx
@@ -512,7 +512,7 @@ void vtkvmtkITKImageWriter::Write()
         float outValue[6];
         for(int i=0; i<out->GetNumberOfTuples(); i++)
           {
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
           in->GetTypedTuple(i, inValue);
 #else
           in->GetTupleValue(i, inValue);


### PR DESCRIPTION
I am trying to build vmtk with brew on MacOS X.
I have found two issues:

./distribution/homebrew/vmtk.rb :
- is not pointing to the last release
- does not recognize python 

VTK_MAJOR_VERSION : brew installs VTK 8.0.0 but the MACROS for 7 and later are set for MINOR => 1

I have fixed the second issue. For the first one I only have a hard fix on the file.
