### PR TITLE
fixed scriptname error in contrib scripts

### DIFF
--- a/vmtkScripts/contrib/vmtkentityrenumber.py
+++ b/vmtkScripts/contrib/vmtkentityrenumber.py
@@ -10,7 +10,7 @@ class VmtkEntityRenumber(pypes.pypeScript):
     def __init__(self):
         pypes.pypeScript.__init__(self)
 
-        self.SetScriptName(vmtkentityrenumber)
+        self.SetScriptName('vmtkentityrenumber')
         self.SetScriptDoc('Renumber cell entity id array.')
 
         self.Mesh = None

--- a/vmtkScripts/contrib/vmtksurfaceextractannularwalls.py
+++ b/vmtkScripts/contrib/vmtksurfaceextractannularwalls.py
@@ -13,7 +13,7 @@ class VmtkSurfaceExtractAnnularWalls(pypes.pypeScript):
     def __init__(self):
         pypes.pypeScript.__init__(self)
 
-        self.SetScriptName(vmtksurfaceextractannularwalls)
+        self.SetScriptName('vmtksurfaceextractannularwalls')
         self.SetScriptDoc('Extract wall surfaces from an annular-cylindric surface.')
 
         # Define members

--- a/vmtkScripts/contrib/vmtksurfaceextractinnercylinder.py
+++ b/vmtkScripts/contrib/vmtksurfaceextractinnercylinder.py
@@ -13,7 +13,7 @@ class VmtkSurfaceExtractInnerCylinder(pypes.pypeScript):
     def __init__(self):
         pypes.pypeScript.__init__(self)
 
-        self.SetScriptName(vmtksurfaceextractinnercylinder)
+        self.SetScriptName('vmtksurfaceextractinnercylinder')
         self.SetScriptDoc('Extract inner surface from an annular-cylindric volume.')
 
         # Define members


### PR DESCRIPTION
while fixing issues related to https://github.com/vmtk/vmtk.github.com/pull/5, the vmtkscripts2html.sh tool found that the following vmtkscripts had errors in their scriptname. this fixes those errors. 

Time to rebuild anaconda packages :)