### PR TITLE
Fix image compare script for newer vtk versions.

### DIFF
--- a/vmtkScripts/vmtkimagecompare.py
+++ b/vmtkScripts/vmtkimagecompare.py
@@ -62,9 +62,9 @@ class vmtkImageCompare(pypes.pypeScript):
             
         imageScalarType = self.Image.GetScalarType()
         referenceScalarType = self.ReferenceImage.GetScalarType()
-        minScalarType = min(imageScalarType,referenceScalarType)
-        self.Image.SetScalarType(minScalarType) 
-        self.ReferenceImage.SetScalarType(minScalarType) 
+        if imageScalarType != referenceScalarType:
+            self.PrintError('Error: Input image and reference image are not of \
+                the same type. Please cast images to the same type.')
 
         imageMath = vtk.vtkImageMathematics()
         imageMath.SetInput1Data(self.Image) 


### PR DESCRIPTION
Prior to VTK 6.0+, the image.SetScalarType() was used to populate
pipeline information with scalar meta-data. This function was removed in
favor of casting methods. However, As users should not be comparing
images with differing types, the code was changed to only check that
scalar types were the same between the input and reference images, and
raise an error otherwise.