### PR TITLE
update depricated numpy function.

### DIFF
--- a/vmtkScripts/contrib/vmtknumpytoimage.py
+++ b/vmtkScripts/contrib/vmtknumpytoimage.py
@@ -71,7 +71,7 @@ class vmtkNumpyToImage(pypes.pypeScript):
 
         self.PrintLog('converting point data')
         for pointKey in self.ArrayDict['PointData'].keys():
-            if np.issubdtype(self.ArrayDict['PointData'][pointKey].dtype, float):
+            if np.issubdtype(self.ArrayDict['PointData'][pointKey].dtype, np.floating):
                 pointDataArrayType = vtk.VTK_FLOAT
             else:
                 for checkDt in [int, np.uint8, np.uint16, np.uint32, np.uint64]:


### PR DESCRIPTION
Update code to check for subclass of np.floating in order to support
future numpy warnings. Deprication warning recieved was:

```
FutureWarning: Conversion of the second argument of issubdtype from
`float` to `np.floating` is deprecated. In future, it will be treated as
`np.float64 == np.dtype(float).type`.
    if np.issubdtype(self.ArrayDict['PointData'][pointKey].dtype, float)
```