### PR TITLE
Fix vmtkdistancetospheres and vmtkdistancetopoints

### DIFF
--- a/vmtkScripts/contrib/vmtkdijkstradistancetopoints.py
+++ b/vmtkScripts/contrib/vmtkdijkstradistancetopoints.py
@@ -289,9 +289,6 @@ class vmtkDijkstraDistanceToPoints(pypes.pypeScript):
  
         self.Surface = self.ComputeDistances()
 
-        if self.Surface.GetSource():
-            self.Surface.GetSource().UnRegisterAllOutputs()
-
         if self.OwnRenderer:
             self.vmtkRenderer.Deallocate()
 

--- a/vmtkScripts/contrib/vmtkdistancetospheres.py
+++ b/vmtkScripts/contrib/vmtkdistancetospheres.py
@@ -361,9 +361,6 @@ class vmtkDistanceToSpheres(pypes.pypeScript):
         
         self.Surface = self.ComputeDistances()
 
-        if self.Surface.GetSource():
-            self.Surface.GetSource().UnRegisterAllOutputs()
-
         if self.OwnRenderer:
             self.vmtkRenderer.Deallocate()
 


### PR DESCRIPTION
removed surface.GetSource() method as this was removed from recent version of VTK

Thank you to Alain Berod for reporting at https://groups.google.com/forum/#!topic/vmtk-users/_STiPkaLWMU
