### PR TITLE
Fixed build errors with VTK8.1

### DIFF
--- a/vmtkScripts/contrib/vmtkmeshaddexternallayer.py
+++ b/vmtkScripts/contrib/vmtkmeshaddexternallayer.py
@@ -228,7 +228,10 @@ class vmtkMeshAddExternalLayer(pypes.pypeScript):
             #offset the previous cellentityids to make room for the new ones
             arrayCalculator = vtk.vtkArrayCalculator()
             arrayCalculator.SetInputData(self.Mesh)
-            arrayCalculator.SetAttributeModeToUseCellData()
+            if vtk.vtkVersion.GetVTKMajorVersion()>=9 or (vtk.vtkVersion.GetVTKMajorVersion()>=8 and vtk.vtkVersion.GetVTKMinorVersion()>=1):
+                arrayCalculator.SetAttributeTypeToCellData()
+            else:
+                arrayCalculator.SetAttributeModeToUseCellData()
             arrayCalculator.AddScalarVariable("entityid",self.CellEntityIdsArrayName,0)
             arrayCalculator.SetFunction("if( entityid > " + str(self.InletOutletCellEntityId-1) +", entityid + " + str(wallOffset) + ", entityid)")
             arrayCalculator.SetResultArrayName('CalculatorResult')

--- a/vmtkScripts/vmtkmeshcompare.py
+++ b/vmtkScripts/vmtkmeshcompare.py
@@ -46,11 +46,17 @@ class vmtkMeshCompare(pypes.pypeScript):
         if self.Method == 'pointarray':
             attributeData = self.Mesh.GetPointData()
             referenceAttributeData = self.ReferenceMesh.GetPointData()
-            calculator.SetAttributeModeToUsePointData()
+            if vtk.vtkVersion.GetVTKMajorVersion()>=9 or (vtk.vtkVersion.GetVTKMajorVersion()>=8 and vtk.vtkVersion.GetVTKMinorVersion()>=1):
+                calculator.SetAttributeTypeToPointData()
+            else:
+                calculator.SetAttributeModeToUsePointData()
         elif self.Method == 'cellarray':
             attributeData = self.Mesh.GetCellData()
             referenceAttributeData = self.ReferenceMesh.GetCellData()
-            calculator.SetAttributeModeToUseCellData()
+            if vtk.vtkVersion.GetVTKMajorVersion()>=9 or (vtk.vtkVersion.GetVTKMajorVersion()>=8 and vtk.vtkVersion.GetVTKMinorVersion()>=1):
+                calculator.SetAttributeTypeToCellData()
+            else:
+                calculator.SetAttributeModeToUseCellData()
  
         if not self.ArrayName:
             self.PrintError('Error: No ArrayName.') 

--- a/vmtkScripts/vmtksurfacecompare.py
+++ b/vmtkScripts/vmtksurfacecompare.py
@@ -50,11 +50,18 @@ class vmtkSurfaceCompare(pypes.pypeScript):
         if self.Method in ['addpointarray','projection']:
             attributeData = self.Surface.GetPointData()
             referenceAttributeData = self.ReferenceSurface.GetPointData()
-            calculator.SetAttributeModeToUsePointData()
+            if vtk.vtkVersion.GetVTKMajorVersion()>=9 or (vtk.vtkVersion.GetVTKMajorVersion()>=8 and vtk.vtkVersion.GetVTKMinorVersion()>=1):
+                calculator.SetAttributeTypeToPointData()
+            else:
+                calculator.SetAttributeModeToUsePointData()
         elif self.Method in ['addcellarray']:
             attributeData = self.Surface.GetCellData()
             referenceAttributeData = self.ReferenceSurface.GetCellData()
-            calculator.SetAttributeModeToUseCellData()
+            if vtk.vtkVersion.GetVTKMajorVersion()>=9 or (vtk.vtkVersion.GetVTKMajorVersion()>=8 and vtk.vtkVersion.GetVTKMinorVersion()>=1):
+                calculator.SetAttributeTypeToCellData()
+            else:
+                calculator.SetAttributeModeToUseCellData()
+
 
         if not attributeData.GetArray(self.ArrayName):
             self.PrintError('Error: Invalid ArrayName.')

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkMergeCenterlines.cxx
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkMergeCenterlines.cxx
@@ -315,7 +315,7 @@ int vtkvmtkMergeCenterlines::RequestData(vtkInformation *vtkNotUsed(request), vt
   tupleValue[0] = tupleValue[1] = -1;
   for (i=0; i<numberOfMergedCells; i++)
     {
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
     cellAdditionalEndPointIds->SetTypedTuple(i, tupleValue);
 #else
     cellAdditionalEndPointIds->SetTupleValue(i, tupleValue);
@@ -356,13 +356,13 @@ int vtkvmtkMergeCenterlines::RequestData(vtkInformation *vtkNotUsed(request), vt
         groupUniqueCellIds->Delete();
         }
       vtkIdType tupleValue[2];
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
       cellAdditionalEndPointIds->GetTypedTuple(mergedCellId,tupleValue);
 #else
       cellAdditionalEndPointIds->GetTupleValue(mergedCellId, tupleValue);
 #endif
       tupleValue[1] = bifurcationPointId;
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
       cellAdditionalEndPointIds->SetTypedTuple(mergedCellId, tupleValue);
 #else
       cellAdditionalEndPointIds->SetTupleValue(mergedCellId, tupleValue);
@@ -386,13 +386,13 @@ int vtkvmtkMergeCenterlines::RequestData(vtkInformation *vtkNotUsed(request), vt
         groupUniqueCellIds->Delete();
         }
       vtkIdType tupleValue[2];
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
       cellAdditionalEndPointIds->GetTypedTuple(mergedCellId, tupleValue);
 #else
       cellAdditionalEndPointIds->GetTupleValue(mergedCellId,tupleValue);
 #endif
       tupleValue[0] = bifurcationPointId;
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
       cellAdditionalEndPointIds->SetTypedTuple(mergedCellId, tupleValue);
 #else
       cellAdditionalEndPointIds->SetTupleValue(mergedCellId,tupleValue);
@@ -421,7 +421,7 @@ int vtkvmtkMergeCenterlines::RequestData(vtkInformation *vtkNotUsed(request), vt
     pts = NULL;
     outputLines->GetNextCell(npts,pts);
     vtkIdType tupleValue[2];
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
     cellAdditionalEndPointIds->GetTypedTuple(i, tupleValue);
 #else
     cellAdditionalEndPointIds->GetTupleValue(i,tupleValue);

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataCenterlines.cxx
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataCenterlines.cxx
@@ -274,7 +274,12 @@ int vtkvmtkPolyDataCenterlines::RequestData(
 #else
   voronoiCostFunctionCalculator->SetInputData(voronoiDiagram);
 #endif
+
+#if VTK_MAJOR_VERSION >= 9  || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 1)
+  voronoiCostFunctionCalculator->SetAttributeTypeToPointData();
+#else
   voronoiCostFunctionCalculator->SetAttributeModeToUsePointData();
+#endif
   voronoiCostFunctionCalculator->AddScalarVariable("R",this->RadiusArrayName,0);
   voronoiCostFunctionCalculator->SetFunction(this->CostFunction);
   voronoiCostFunctionCalculator->SetResultArrayName(this->CostFunctionArrayName);

--- a/vtkVmtk/Misc/vtkvmtkPolyDataNetworkExtraction.cxx
+++ b/vtkVmtk/Misc/vtkvmtkPolyDataNetworkExtraction.cxx
@@ -174,7 +174,7 @@ void vtkvmtkPolyDataNetworkExtraction::InsertInEdgeTable(vtkIdTypeArray* edgeTab
   vtkIdType edge[2];
   edge[0] = pointId0;
   edge[1] = pointId1;
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
   edgeTable->InsertNextTypedTuple(edge);
 #else
   edgeTable->InsertNextTupleValue(edge);
@@ -190,7 +190,7 @@ bool vtkvmtkPolyDataNetworkExtraction::InsertUniqueInEdgeTable(vtkIdTypeArray* e
   for (i=0; i<edgeTable->GetNumberOfTuples(); i++)
     {
     vtkIdType currentEdge[2];
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
     edgeTable->GetTypedTuple(i, currentEdge);
 #else
     edgeTable->GetTupleValue(i,currentEdge);
@@ -201,7 +201,7 @@ bool vtkvmtkPolyDataNetworkExtraction::InsertUniqueInEdgeTable(vtkIdTypeArray* e
       }
     }
 
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
   edgeTable->InsertNextTypedTuple(edge);
 #else
   edgeTable->InsertNextTupleValue(edge);
@@ -212,7 +212,7 @@ bool vtkvmtkPolyDataNetworkExtraction::InsertUniqueInEdgeTable(vtkIdTypeArray* e
 
 void vtkvmtkPolyDataNetworkExtraction::GetFromEdgeTable(vtkIdTypeArray* edgeTable, vtkIdType position, vtkIdType edge[2])
 {
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
   edgeTable->GetTypedTuple(position, edge);
 #else
   edgeTable->GetTupleValue(position,edge);
@@ -1312,7 +1312,7 @@ void vtkvmtkPolyDataNetworkExtraction::BuildSegment(vtkPoints* segmentPoints, vt
   segmentTopologyArray->SetName(TopologyArrayName);
   segmentTopologyArray->SetNumberOfComponents(2);
 
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
   segmentTopologyArray->InsertNextTypedTuple(segmentTopology);
 #else
   segmentTopologyArray->InsertNextTupleValue(segmentTopology);
@@ -1561,7 +1561,7 @@ void vtkvmtkPolyDataNetworkExtraction::JoinSegments (vtkPolyData* segment0, vtkP
   vtkIdType segmentTopology0[2];
   vtkIdType segmentTopology1[2];
 
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
   segment0TopologyArray->GetTypedTuple(0, segmentTopology0);
   segment1TopologyArray->GetTypedTuple(0, segmentTopology1);
 #else
@@ -1610,7 +1610,7 @@ void vtkvmtkPolyDataNetworkExtraction::JoinSegments (vtkPolyData* segment0, vtkP
       }
     }
  
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
   topologyArray->InsertNextTypedTuple(segmentTopology);
 #else
   topologyArray->InsertNextTupleValue(segmentTopology);
@@ -1656,7 +1656,7 @@ void vtkvmtkPolyDataNetworkExtraction::RemoveDegenerateBifurcations(vtkPolyDataC
 //    vtkDoubleArray* radiusArray = vtkDoubleArray::SafeDownCast(segment->GetPointData()->GetArray(RadiusArrayName));
     vtkIdTypeArray* topologyArray = vtkIdTypeArray::SafeDownCast(segment->GetCellData()->GetArray(TopologyArrayName));
     vtkIdType topology[2];
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
     topologyArray->GetTypedTuple(0, topology);
 #else
     topologyArray->GetTupleValue(0,topology);
@@ -1704,7 +1704,7 @@ void vtkvmtkPolyDataNetworkExtraction::RemoveDegenerateBifurcations(vtkPolyDataC
 //      vtkDoubleArray* radiusArray = vtkDoubleArray::SafeDownCast(currentSegment->GetPointData()->GetArray(RadiusArrayName));
       vtkIdTypeArray* topologyArray = vtkIdTypeArray::SafeDownCast(currentSegment->GetCellData()->GetArray(TopologyArrayName));
       vtkIdType topology[2];
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
       topologyArray->GetTypedTuple(0,topology);
 #else
       topologyArray->GetTupleValue(0,topology);
@@ -1767,7 +1767,7 @@ void vtkvmtkPolyDataNetworkExtraction::RemoveDegenerateBifurcations(vtkPolyDataC
 //    vtkDoubleArray* radiusArray = vtkDoubleArray::SafeDownCast(currentSegment->GetPointData()->GetArray(RadiusArrayName));
     vtkIdTypeArray* topologyArray = vtkIdTypeArray::SafeDownCast(currentSegment->GetCellData()->GetArray(TopologyArrayName));
     vtkIdType topology[2];
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
     topologyArray->GetTypedTuple(0, topology);
 #else
     topologyArray->GetTupleValue(0, topology);
@@ -1784,7 +1784,7 @@ void vtkvmtkPolyDataNetworkExtraction::RemoveDegenerateBifurcations(vtkPolyDataC
       position1=realBifurcations->InsertUniqueId(scalar1);
       topology[1] = position1;
       }
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
     topologyArray->InsertTypedTuple(0,topology);
 #else
     topologyArray->InsertTupleValue(0,topology);
@@ -1855,7 +1855,7 @@ void vtkvmtkPolyDataNetworkExtraction::GlobalIteration(vtkPolyData* model, vtkPo
     {
     vtkIdType topology[2];
     vtkIdTypeArray* segmentTopologyArray = vtkIdTypeArray::SafeDownCast(segments->GetNextItem()->GetCellData()->GetArray(TopologyArrayName));
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
     segmentTopologyArray->GetTypedTuple(0, topology);
     topologyArray->InsertNextTypedTuple(topology);
 #else
@@ -1931,7 +1931,7 @@ void vtkvmtkPolyDataNetworkExtraction::Graph(vtkPolyData* network, vtkPolyData* 
     {
     vtkCell* cell = network->GetCell(i);
     vtkIdType topology[2];
-#if VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1
+#if VTK_MAJOR_VERSION >= 8  || (VTK_MAJOR_VERSION >= 7 && VTK_MINOR_VERSION >= 1)
     topologyArray->GetTypedTuple(i, topology);
 #else
     topologyArray->GetTupleValue(i, topology);


### PR DESCRIPTION
VTK version checks were not fully correct (did not detect VTK 8 and 9 if minor version was 0).

Fixed calculator method calls according to API change in VTK 8.1:
SetAttributeModeToUsePointData was renamed to SetAttributeTypeToPointData
SetAttributeModeToUseCellData was renamed to SetAttributeTypeToCellData

Note: I have tested C++ changes but not tested the Python file changes (I just use the C++ interface).