### PR TITLE
enabled test_vmtkimagevesselenhacement VED filter

### DIFF
--- a/tests/test_vmtkScripts/test_vmtkimagevesselenhancement.py
+++ b/tests/test_vmtkScripts/test_vmtkimagevesselenhancement.py
@@ -81,7 +81,8 @@ def test_sato_enhancement_with_varied_params(aorta_image, compare_images,
 
 # for whatever reason the VED filter errors out on linux. Not sure why since this works on Mac
 # and Windows. Need to look into this. 
-@pytest.mark.skipif(sys.platform.startswith('linux') == True)
+@pytest.mark.skipif(sys.platform.startswith('linux') == True, 
+reason='for whatever reason the VED filter errors out on linux. Not sure why since this works on Mac and Windows. Need to look into this.')
 @pytest.mark.parametrize("alpha,beta,gamma,c,timestep,epsilon,wstrength,\
                          sensitivity,numiterations,numdiffusioniterations,paramid", [
     (1.5, 0.5, 5.0, 1E-6, 1E-2, 1E-2, 25.0, 5.0, 1, 0, '0'),

--- a/tests/test_vmtkScripts/test_vmtkimagevesselenhancement.py
+++ b/tests/test_vmtkScripts/test_vmtkimagevesselenhancement.py
@@ -15,6 +15,7 @@
 ##       University at Buffalo
 
 import pytest
+import sys
 import vmtk.vmtkimagevesselenhancement as vesselenhancement
 
 
@@ -78,7 +79,9 @@ def test_sato_enhancement_with_varied_params(aorta_image, compare_images,
 
     assert compare_images(enhancer.Image, name) == True
 
-@pytest.mark.skip(reason='failing on linux for unknown reason')
+# for whatever reason the VED filter errors out on linux. Not sure why since this works on Mac
+# and Windows. Need to look into this. 
+@pytest.mark.skipif(sys.platform.startswith('linux') == True)
 @pytest.mark.parametrize("alpha,beta,gamma,c,timestep,epsilon,wstrength,\
                          sensitivity,numiterations,numdiffusioniterations,paramid", [
     (1.5, 0.5, 5.0, 1E-6, 1E-2, 1E-2, 25.0, 5.0, 1, 0, '0'),


### PR DESCRIPTION
On windows and MacOSX. For whatever reason the VED filter is broken on linux right now, not sure why. 