### PR TITLE
feat: Add ability to filter on bright background and Cast image to float

### DIFF
--- a/vmtkScripts/vmtkimagevesselenhancement.py
+++ b/vmtkScripts/vmtkimagevesselenhancement.py
@@ -51,6 +51,7 @@ class vmtkImageVesselEnhancement(pypes.pypeScript):
         self.Sensitivity = 5.0
         self.NumberOfIterations = 0
         self.NumberOfDiffusionSubIterations = 0
+        self.BrightObject = True
 
         self.SetScriptName('vmtkimagevesselenhancement')
         self.SetScriptDoc('compute a feature image for use in segmentation')
@@ -62,6 +63,7 @@ class vmtkImageVesselEnhancement(pypes.pypeScript):
             ['NumberOfSigmaSteps','sigmasteps','int',1,'(0,)'],
             ['SigmaStepMethod','stepmethod','str',1,'["equispaced","logarithmic"]'],
             ['ScaledVesselness','scaled','bool',1,'','(frangi)'],
+            ['BrightObject','brightobject','bool',1,'','(frangi)'],
             ['Alpha1','alpha1','float',1,'(0.0,)','(sato)'],
             ['Alpha2','alpha2','float',1,'(0.0,)','(sato)'],
             ['Alpha','alpha','float',1,'(0.0,)','(frangi, ved, vedm)'],
@@ -90,6 +92,7 @@ class vmtkImageVesselEnhancement(pypes.pypeScript):
         vesselness.SetAlpha(self.Alpha)
         vesselness.SetBeta(self.Beta)
         vesselness.SetGamma(self.Gamma)
+        vesselness.SetBrightObject(self.BrightObject)
         if self.SigmaStepMethod == 'equispaced':
             vesselness.SetSigmaStepMethodToEquispaced()
         elif self.SigmaStepMethod == 'logarithmic':
@@ -175,6 +178,19 @@ class vmtkImageVesselEnhancement(pypes.pypeScript):
 
         if self.SigmaMax < self.SigmaMin:
             self.SigmaMax = self.SigmaMin
+
+        if( self.Image.GetScalarType() != vtk.VTK_FLOAT):
+          # filters only work on float
+          print("input type not of type float, casting to float")
+          #TODO use rescale filter for proper mapping
+          cast = vtk.vtkImageCast()
+          cast.SetInputData(self.Image)
+          cast.SetOutputScalarTypeToFloat()
+          cast.Update()
+          self.Image.DeepCopy(cast.GetOutput())
+
+        if(self.Image.GetDataDimension() != 3):
+          self.PrintError('Error: unsupported image dimension, expected {0}D image'.format(3))
 
         if self.Method == 'frangi':
             self.ApplyFrangiVesselness()

--- a/vtkVmtk/Segmentation/vtkvmtkVesselnessMeasureImageFilter.cxx
+++ b/vtkVmtk/Segmentation/vtkvmtkVesselnessMeasureImageFilter.cxx
@@ -44,6 +44,7 @@ vtkvmtkVesselnessMeasureImageFilter::vtkvmtkVesselnessMeasureImageFilter()
   this->Beta = 1.0;
   this->Gamma = 1.0;
   this->ScalesOutput = NULL;
+  this->BrightObject = true;
 }
 
 vtkvmtkVesselnessMeasureImageFilter::~vtkvmtkVesselnessMeasureImageFilter()
@@ -71,7 +72,7 @@ void vtkvmtkVesselnessMeasureImageFilter::SimpleExecute(vtkImageData* input, vtk
 
   VesselnessFilterType::Pointer vesselnessFilter = VesselnessFilterType::New();
   vesselnessFilter->SetScaleObjectnessMeasure(this->UseScaledVesselness);
-  vesselnessFilter->SetBrightObject(true);
+  vesselnessFilter->SetBrightObject(this->BrightObject);
   vesselnessFilter->SetObjectDimension(1);
   vesselnessFilter->SetAlpha(this->Alpha);
   vesselnessFilter->SetBeta(this->Beta);

--- a/vtkVmtk/Segmentation/vtkvmtkVesselnessMeasureImageFilter.h
+++ b/vtkVmtk/Segmentation/vtkvmtkVesselnessMeasureImageFilter.h
@@ -83,6 +83,10 @@ class VTK_VMTK_SEGMENTATION_EXPORT vtkvmtkVesselnessMeasureImageFilter : public 
   vtkSetMacro(Gamma,double);
 
   vtkGetObjectMacro(ScalesOutput,vtkImageData);
+  
+  vtkSetMacro(BrightObject, bool);
+  vtkGetMacro(BrightObject, bool);
+  vtkBooleanMacro(BrightObject, bool);
 
 protected:
   vtkvmtkVesselnessMeasureImageFilter();
@@ -102,6 +106,7 @@ private:
   double Alpha;
   double Beta;
   double Gamma;
+  bool BrightObject;
   vtkImageData* ScalesOutput;
 };
 


### PR DESCRIPTION
This addresses  #243 by casting the input image to float.

There is a TODO around rescaling the input image such that data is not truncated but linearly fit to the data type to reduce the data loss.

I also added the ability to run the filter on dark objects on bright background.

This does not yet include a check in the c++ for the data type and exiting nicely 