### PR TITLE
add invert to transform surface from RAS back to XYZ 

### DIFF
--- a/tests/test_vmtkScripts/CMakeLists.txt
+++ b/tests/test_vmtkScripts/CMakeLists.txt
@@ -53,6 +53,7 @@ set(TEST_VMTKSCRIPTS_SRCS
     test_vmtksurfacescaling.py
     test_vmtksurfacesmoothing.py
     test_vmtksurfacesubdivision.py
+    test_vmtksurfacetransformtoras.py
     )
 
 IF(NOT TEST_VMTKSCRIPTS_INSTALL_LIB_DIR)

--- a/tests/test_vmtkScripts/test_vmtksurfacetransformtoras.py
+++ b/tests/test_vmtkScripts/test_vmtksurfacetransformtoras.py
@@ -1,0 +1,68 @@
+## Program: VMTK
+## Language:  Python
+## Date:      April 9, 2018
+## Version:   1.4.1
+
+##   Copyright (c) Richard Izzo, Luca Antiga, All rights reserved.
+##   See LICENCE file for details.
+
+##      This software is distributed WITHOUT ANY WARRANTY; without even
+##      the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+##      PURPOSE.  See the above copyright notices for more information.
+
+## Note: this code was contributed by
+##       Richard Izzo (Github @rlizzo)
+##       University at Buffalo
+
+import pytest
+import os
+import vmtk.vmtksurfacetransformtoras as transformtoras
+
+@pytest.fixture(scope='module')
+def transform_image(input_datadir):
+    import vmtk.vmtkimagereader as imagereader
+    reader = imagereader.vmtkImageReader()
+    reader.InputFileName = os.path.join(input_datadir, 'image-test-transform.nrrd')
+    reader.Execute()
+    return (reader.Image, reader.XyzToRasMatrixCoefficients)
+
+
+def test_default_parameters(transform_image, compare_surfaces):
+    name = __name__ + '_test_default_parameters.stl'
+    import vmtk.vmtkmarchingcubes as marching
+    image = transform_image[0]
+    matrixCoefficients = transform_image[1]
+    mc = marching.vmtkMarchingCubes()
+    mc.Image = image
+    mc.Level = 3000.0
+    mc.Execute()
+
+    transform = transformtoras.vmtkSurfaceTransformToRAS()
+    transform.Surface = mc.Surface
+    transform.XyzToRasMatrixCoefficients = matrixCoefficients
+    transform.Execute()
+    assert compare_surfaces(transform.Surface, name) == True
+
+
+def test_invert_on(transform_image, compare_surfaces):
+    name = __name__ + '_test_invert_on.stl'
+    import vmtk.vmtkmarchingcubes as marching
+    image = transform_image[0]
+    matrixCoefficients = transform_image[1]
+    mc = marching.vmtkMarchingCubes()
+    mc.Image = image
+    mc.Level = 3000.0
+    mc.Execute()
+
+    transform = transformtoras.vmtkSurfaceTransformToRAS()
+    transform.Surface = mc.Surface
+    transform.XyzToRasMatrixCoefficients = matrixCoefficients
+    transform.InvertMatrix = 1
+    transform.Execute()
+    assert compare_surfaces(transform.Surface, name) == True
+
+
+
+
+
+    

--- a/vmtkScripts/vmtksurfacetransformtoras.py
+++ b/vmtkScripts/vmtksurfacetransformtoras.py
@@ -6,7 +6,7 @@
 ## Date:      $Date: Sun Feb 21 17:02:37 CET 2010$
 ## Version:   $Revision: 1.0 $
 
-##   Copyright (c) Luca Antiga, David Steinman. All rights reserved.
+##   Copyright (c) Luca Antiga. All rights reserved.
 ##   See LICENCE file for details.
 
 ##      This software is distributed WITHOUT ANY WARRANTY; without even 
@@ -28,12 +28,14 @@ class vmtkSurfaceTransformToRAS(pypes.pypeScript):
 
         self.Surface = None
         self.XyzToRasMatrixCoefficients = None
+        self.InvertMatrix = 0
 
         self.SetScriptName('vmtksurfacetransformtoras')
         self.SetScriptDoc('transform a surface generated in XYZ image space into RAS space')
         self.SetInputMembers([
             ['Surface','i','vtkPolyData',1,'','the input surface','vmtksurfacereader'],
-            ['XyzToRasMatrixCoefficients','matrix','float',16,'','coefficients of XYZToRAS transform matrix']
+            ['XyzToRasMatrixCoefficients','matrix','float',16,'','coefficients of XYZToRAS transform matrix'],
+            ['InvertMatrix','invert','bool',1,'','invert matrix before applying transformation']
             ])
         self.SetOutputMembers([
             ['Surface','o','vtkPolyData',1,'','the output surface','vmtksurfacewriter']
@@ -49,6 +51,9 @@ class vmtkSurfaceTransformToRAS(pypes.pypeScript):
 
         matrix = vtk.vtkMatrix4x4()
         matrix.DeepCopy(self.XyzToRasMatrixCoefficients)
+        
+        if self.InvertMatrix:
+            matrix.Invert()
 
         transform = vtk.vtkTransform()
         transform.SetMatrix(matrix)

--- a/vmtkScripts/vmtksurfacetransformtoras.py
+++ b/vmtkScripts/vmtksurfacetransformtoras.py
@@ -6,7 +6,7 @@
 ## Date:      $Date: Sun Feb 21 17:02:37 CET 2010$
 ## Version:   $Revision: 1.0 $
 
-##   Copyright (c) Luca Antiga. All rights reserved.
+##   Copyright (c) Luca Antiga, David Steinman. All rights reserved.
 ##   See LICENCE file for details.
 
 ##      This software is distributed WITHOUT ANY WARRANTY; without even 
@@ -35,7 +35,8 @@ class vmtkSurfaceTransformToRAS(pypes.pypeScript):
         self.SetInputMembers([
             ['Surface','i','vtkPolyData',1,'','the input surface','vmtksurfacereader'],
             ['XyzToRasMatrixCoefficients','matrix','float',16,'','coefficients of XYZToRAS transform matrix'],
-            ['InvertMatrix','invert','bool',1,'','invert matrix before applying transformation']
+            ['InvertMatrix','invert','bool',1,'',
+             'invert XyzToRasMatrixCoefficients matrix, additional transforms to surface in RAS space requires the inverse transform reverting the surface back to an axis aligned frame']
             ])
         self.SetOutputMembers([
             ['Surface','o','vtkPolyData',1,'','the output surface','vmtksurfacewriter']

--- a/vmtkScripts/vmtksurfacetransformtoras.py
+++ b/vmtkScripts/vmtksurfacetransformtoras.py
@@ -35,8 +35,7 @@ class vmtkSurfaceTransformToRAS(pypes.pypeScript):
         self.SetInputMembers([
             ['Surface','i','vtkPolyData',1,'','the input surface','vmtksurfacereader'],
             ['XyzToRasMatrixCoefficients','matrix','float',16,'','coefficients of XYZToRAS transform matrix'],
-            ['InvertMatrix','invert','bool',1,'',
-             'invert XyzToRasMatrixCoefficients matrix, additional transforms to surface in RAS space requires the inverse transform reverting the surface back to an axis aligned frame']
+            ['InvertMatrix','invert','bool',1,'','invert XyzToRasMatrixCoefficients matrix, additional transforms to surface in RAS space requires the inverse transform reverting the surface back to an axis aligned frame']
             ])
         self.SetOutputMembers([
             ['Surface','o','vtkPolyData',1,'','the output surface','vmtksurfacewriter']


### PR DESCRIPTION
There is a use case where Slicer registration tools are used to map different image modalities to the same image space. however if the segmentation is performed on the un-transformed image there is not an easy mapping between the different coordinate frames that such that paraview can be used.

adding invert to vmtksurfacetransformtoras.py provides the following workflow.
1. extract surface from a image volume (DSA for example) using VMTK
2. transform surface to ras (normal use case) using VMTK
3. manually/automated registration in RAS space (slicer) of DSA to MRI (SLICER)
4. transform surface in RAS space using registration transforms (SLICER)
5. apply inverse xyz2ras transform from the registered image to the registered surface to get surface that matches space of image in paraview (VMTK)

caveat: The registered image volume must be converted to the vti format with vmtk. Paraview can't read compressed nrrd format (slicer default) and mha format doesn't match space (Paraview issue of vmtkimagewriter may have bug see #254 ) 
