### PR TITLE
add 'all' feature to surface connectivity with surface tags

### DIFF
--- a/vmtkScripts/vmtksurfaceconnectivity.py
+++ b/vmtkScripts/vmtksurfaceconnectivity.py
@@ -39,10 +39,10 @@ class vmtkSurfaceConnectivity(pypes.pypeScript):
         self.CleanOutput = 0
 
         self.SetScriptName('vmtksurfaceconnectivity')
-        self.SetScriptDoc('extract the largest connected region, the closest point-connected region or the scalar-connected region from a surface')
+        self.SetScriptDoc('extract the largest connected region, the closest point-connected region, the scalar-connected region from a surface, or all connected regions of a surface tagged with an id')
         self.SetInputMembers([
             ['Surface','i','vtkPolyData',1,'','the input surface','vmtksurfacereader'],
-            ['Method','method','str',1,'["largest","closest"]','connectivity method'],
+            ['Method','method','str',1,'["largest","closest", "all"]','connectivity method'],
             ['ClosestPoint','closestpoint','float',3,'','coordinates of the closest point'],
             ['ReferenceSurface','r','vtkPolyData',1,'','the reference surface, whose barycenter will be used as closest point for the connectivity filter','vmtksurfacereader'],
             ['CleanOutput','cleanoutput','bool',1,'','clean the unused points in the output'],
@@ -84,6 +84,10 @@ class vmtkSurfaceConnectivity(pypes.pypeScript):
                 connectivityFilter.SetClosestPoint(self.ClosestPoint)
             else:
                 connectivityFilter.SetClosestPoint(barycenter)
+        elif self.Method == 'all':
+            connectivityFilter.SetExtractionModeToAllRegions()
+            connectivityFilter.ColorRegionsOn()
+
         if self.GroupId != -1:
             connectivityFilter.ScalarConnectivityOn()
             scalarRange = [self.GroupId,self .GroupId]


### PR DESCRIPTION
Sometimes the largest region is not what you want or maybe you need multiple surfaces.

The nice thing is that this will tag each connected surface which can then be filtered in paraview.