### PR TITLE
Fixes rebuilding VMTK after change to source files.

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -181,6 +181,7 @@ ExternalProject_Add( ${proj}
   DOWNLOAD_COMMAND ""
   SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
   BINARY_DIR VMTK-Build
+  BUILD_ALWAYS 1 # always run this step. do not generate stamp file 
   CMAKE_GENERATOR ${gen}
   USES_TERMINAL_CONFIGURE 1
   USES_TERMINAL_BUILD 1


### PR DESCRIPTION
When the CMake option "USE_SUPERBUILD" is enabled, CMake treats VMTK as
an External Project which pulls its source from the local disk. By
building in this manner, the CMake configures both the compilation and
instalation step to occur at the same time with a single call to "make".

While this works when a project is built from source (the first time),
the default behavior of an external project is to not feed in the source
files as a dependency of the generated install. As a complete list of
header files is not given as input to the build step, there is nothing
to indicate that the build step should re-run. Any changes which are
made to the source directory are therefore not rebuilt in the
installation directory.

By setting the CMake External Project option BUILD_ALWAYS 1, a build
timestamp file is not generated by cmake, and this external project
always builds, therefore picking up any changes in the source.