### PR TITLE
Add Multiple Seed Colliding Fronts Method to vmtkImageInitialization

### DIFF
--- a/vmtkScripts/vmtkimageseeder.py
+++ b/vmtkScripts/vmtkimageseeder.py
@@ -33,6 +33,7 @@ class vmtkImageSeeder(pypes.pypeScript):
         self.OwnRenderer = 0
         self.Display = 1
         self.ArrayName = ''
+        self.SeedRGBColor = [1.0, 0.0, 0.0] # red by default
 
         self.Picker = None
         self.PlaneWidgetX = None
@@ -54,6 +55,7 @@ class vmtkImageSeeder(pypes.pypeScript):
             ['vmtkRenderer','renderer','vmtkRenderer',1,'','external renderer'],
             ['Display','display','bool',1,'','toggle rendering'],
             ['KeepSeeds','keepseeds','bool',1,'','toggle avoid removal of seeds from renderer'],
+            ['SeedRGBColor','seedcolor','float',3,'(0.0,1.0)','RGB Values to set the color of the seed to. red by default'],
             ['TextureInterpolation','textureinterpolation','bool',1,'','toggle interpolation of graylevels on image planes']
             ])
         self.SetOutputMembers([
@@ -146,7 +148,9 @@ class vmtkImageSeeder(pypes.pypeScript):
         glyphMapper.SetInputConnection(glyphs.GetOutputPort())
         self.SeedActor = vtk.vtkActor()
         self.SeedActor.SetMapper(glyphMapper)
-        self.SeedActor.GetProperty().SetColor(1.0,0.0,0.0)
+        self.SeedActor.GetProperty().SetColor(self.SeedRGBColor[0],
+                                              self.SeedRGBColor[1],
+                                              self.SeedRGBColor[2])
         self.vmtkRenderer.Renderer.AddActor(self.SeedActor)
 
         self.WidgetsOn()


### PR DESCRIPTION
This is in response to a [question posted on the mailing list](https://groups.google.com/forum/#!topic/vmtk-users/9YghcHqjSc8) by @kayarre and commented on by @lantiga and myself. 

This PR attempts to extend the colliding fronts method to allow for multiple seeds to be selected at the same time. The PR currently works (with a few bugs in the seed colors). 

Instead of being limited to selecting two seeds at a time, the user is allowed to input any arbitrary amount of seeds (as long as the total number is even). Every two seeds selected are assumed to belong to a single colliding front "seed pair". The colliding fronts initial level set is calculated `numSeeds / 2` times, once for each seed pair. These are then summed together to produce the "final" (combined) initial level set which is set as the script output. 

Looking forward to your feedback, not sure if there is a easier way to accomplish this task. 