### PR TITLE
Fix TypeError raised by font size in vmtkrenderer

### DIFF
--- a/vmtkScripts/vmtkrenderer.py
+++ b/vmtkScripts/vmtkrenderer.py
@@ -121,7 +121,7 @@ class vmtkRenderer(pypes.pypeScript):
 
         baseFontScalePerPixelWidth = math.floor(baseScreenWidth / baseFontSize)
 
-        scaledFontSize = math.ceil(userScreenWidth / baseFontScalePerPixelWidth)
+        scaledFontSize = int(math.ceil(userScreenWidth / baseFontScalePerPixelWidth))
 
         # make sure that the font size won't be set too low or high for low/high screen resolutions. 
         if scaledFontSize < 8:


### PR DESCRIPTION
Force [_GetScreenFontSize](https://github.com/vmtk/vmtk/blob/master/vmtkScripts/vmtkrenderer.py#L101-L133) to return an `int` value, avoiding a `TypeError` when trying to set the font size.