### PR TITLE
Fix build error with new VTK 8.2

### DIFF
--- a/CMake/vtkMacroKitPythonWrap.cmake
+++ b/CMake/vtkMacroKitPythonWrap.cmake
@@ -80,7 +80,7 @@ endmacro()
 #!
 #!   Slicer_VTK_WRAP_HIERARCHY_DIR:
 #!
-#!     Directory where to ouptut the hierarchy files
+#!     Directory where to output the hierarchy files
 #!     Default is ${Slicer_BINARY_DIR}
 #!
 #!   Slicer_VTK_WRAP_MODULE_INSTALL_COMPONENT_IDENTIFIER:
@@ -192,7 +192,7 @@ macro(vtkMacroKitPythonWrap)
       #  - <module_name>_WRAP_HIERARCHY_FILE
       set(${MY_KIT_NAME}_WRAP_DEPENDS "${_kit_wrap_depends}" CACHE INTERNAL "${MY_KIT_NAME} wrapping dependencies" FORCE)
       set(_wrap_hierarchy_file "${Slicer_VTK_WRAP_HIERARCHY_DIR}/${MY_KIT_NAME}Hierarchy.txt")
-      if(${VTK_VERSION_MAJOR} VERSION_LESS 9)
+      if(${VTK_VERSION_MAJOR}.${VTK_VERSION_MINOR} VERSION_LESS "8.2")
         set(_wrap_hierarchy_stamp_file ${CMAKE_CURRENT_BINARY_DIR}/${MY_KIT_NAME}Hierarchy.stamp.txt)
       endif()
       set(${MY_KIT_NAME}_WRAP_HIERARCHY_FILE "${_wrap_hierarchy_file}" CACHE INTERNAL "${MY_KIT_NAME} wrap hierarchy file" FORCE)
@@ -219,7 +219,7 @@ macro(vtkMacroKitPythonWrap)
     # hierarchy file is created.
     # XXX Use target_sources if cmake_minimum_required >= 3.1
     get_target_property(_kit_srcs ${MY_KIT_NAME} SOURCES)
-    if(${VTK_VERSION_MAJOR} VERSION_LESS 9)
+    if(${VTK_VERSION_MAJOR}.${VTK_VERSION_MINOR} VERSION_LESS "8.2")
       list(APPEND _kit_srcs ${_wrap_hierarchy_stamp_file})
     else()
       list(APPEND _kit_srcs ${_wrap_hierarchy_file})

--- a/vtkVmtk/IO/vtkvmtkFDNEUTReader.cxx
+++ b/vtkVmtk/IO/vtkvmtkFDNEUTReader.cxx
@@ -65,14 +65,14 @@ int vtkvmtkFDNEUTReader::RequestData(
     return 1;
     }
 
-  if (!this->FileName)
+  if (!this->GetFileName())
     {
     vtkErrorMacro(<<"FileName not set.");
     return 1;
     }
         
   FILE* FDNEUTFile;
-  FDNEUTFile = fopen(this->FileName,"r");
+  FDNEUTFile = fopen(this->GetFileName(),"r");
 
   if (!FDNEUTFile)
     {

--- a/vtkVmtk/IO/vtkvmtkTetGenReader.cxx
+++ b/vtkVmtk/IO/vtkvmtkTetGenReader.cxx
@@ -84,16 +84,16 @@ int vtkvmtkTetGenReader::RequestData(
     return 1;
     }
 
-  if (!this->FileName)
+  if (!this->GetFileName())
     {
     vtkErrorMacro(<<"FileName not set.");
     return 1;
     }
 
-  std::string nodeFileName = this->FileName;
+  std::string nodeFileName = this->GetFileName();
   nodeFileName += ".node";
 
-  std::string eleFileName = this->FileName;
+  std::string eleFileName = this->GetFileName();
   eleFileName += ".ele";
 
   ifstream nodeStream(nodeFileName.c_str());

--- a/vtkVmtk/IO/vtkvmtkXdaReader.cxx
+++ b/vtkVmtk/IO/vtkvmtkXdaReader.cxx
@@ -61,7 +61,7 @@ int vtkvmtkXdaReader::RequestData(
     return 1;
     }
 
-  if (!this->FileName)
+  if (!this->GetFileName())
     {
     vtkErrorMacro(<<"FileName not set.");
     return 1;


### PR DESCRIPTION
Fix build errors when building with recent VTK versions.

1. VTK version was reversed from 9.x to 8.2
2. FileName member variable was renamed

All changes are backward compatible.
