### PR TITLE
Fix Python3 syntax errors due to Python2-style integer division

### DIFF
--- a/vmtkScripts/contrib/vmtkentityrenumber.py
+++ b/vmtkScripts/contrib/vmtkentityrenumber.py
@@ -47,7 +47,7 @@ class VmtkEntityRenumber(pypes.pypeScript):
             self.PrintError('Renumbering must have even length.')
 
         renumbering = {}
-        for i in range(len(self.CellEntityIdRenumbering)/2):
+        for i in range(len(self.CellEntityIdRenumbering)//2):
             a = self.CellEntityIdRenumbering[2*i]
             b = self.CellEntityIdRenumbering[2*i+1]
             renumbering[a] = b

--- a/vmtkScripts/vmtkcenterlinelabeler.py
+++ b/vmtkScripts/vmtkcenterlinelabeler.py
@@ -119,7 +119,7 @@ class vmtkCenterlineLabeler(pypes.pypeScript):
             if len(self.Labeling) != 2 * len(uniqueGroupIds):
                 self.PrintError('Error: incorrect labeling specified')
 
-            for i in range(len(self.Labeling)/2):
+            for i in range(len(self.Labeling)//2):
                 groupId = self.Labeling[2*i]
                 labelId = self.Labeling[2*i+1]
                 if not groupId in uniqueGroupIds:

--- a/vmtkScripts/vmtkimageinitialization.py
+++ b/vmtkScripts/vmtkimageinitialization.py
@@ -205,9 +205,9 @@ class vmtkImageInitialization(pypes.pypeScript):
                 targetSeedIds.InsertNextId(self.Image.FindPoint(targetSeeds.GetPoint(i)))
 
         else:
-            for i in range(int(len(self.SourcePoints)/3)):
+            for i in range(len(self.SourcePoints)//3):
                 sourceSeedIds.InsertNextId(self.Image.ComputePointId([self.SourcePoints[3*i+0],self.SourcePoints[3*i+1],self.SourcePoints[3*i+2]]))
-            for i in range(int(len(self.TargetPoints)/3)):
+            for i in range(len(self.TargetPoints)//3):
                 targetSeedIds.InsertNextId(self.Image.ComputePointId([self.TargetPoints[3*i+0],self.TargetPoints[3*i+1],self.TargetPoints[3*i+2]]))
 
         scalarRange = self.Image.GetScalarRange()
@@ -357,9 +357,9 @@ class vmtkImageInitialization(pypes.pypeScript):
             for i in range(seeds.GetNumberOfPoints()):
                 seedIds.InsertNextId(self.Image.FindPoint(seeds.GetPoint(i)))
         else:
-            for i in range(len(self.SourcePoints)/3):
+            for i in range(len(self.SourcePoints)//3):
                 seedIds.InsertNextId(self.Image.ComputePointId([self.SourcePoints[3*i+0],self.SourcePoints[3*i+1],self.SourcePoints[3*i+2]]))
-            for i in range(len(self.TargetPoints)/3):
+            for i in range(len(self.TargetPoints)//3):
                 seedIds.InsertNextId(self.Image.ComputePointId([self.TargetPoints[3*i+0],self.TargetPoints[3*i+1],self.TargetPoints[3*i+2]]))
         
         self.InitialLevelSets = vtk.vtkImageData()

--- a/vmtkScripts/vmtkpointtransform.py
+++ b/vmtkScripts/vmtkpointtransform.py
@@ -57,7 +57,7 @@ class vmtkPointTransform(pypes.pypeScript):
         transform.SetInput(matrix)
 
         outputPoints = []
-        for i in range(len(self.Points)/3):
+        for i in range(len(self.Points)//3):
             point = [self.Points[3*i+0],self.Points[3*i+1],self.Points[3*i+2]]
             outputPoint = transform.TransformPoint(point)
             outputPoints.append(outputPoint)

--- a/vmtkScripts/vmtksurfacecurvature.py
+++ b/vmtkScripts/vmtksurfacecurvature.py
@@ -111,7 +111,7 @@ class vmtkSurfaceCurvature(pypes.pypeScript):
                 values.sort()
                 if not values:
                     continue
-                medianValue = values[(len(values) - 1)/2]
+                medianValue = values[(len(values) - 1)//2]
                 activeScalars.SetTuple1(pointId,medianValue)
 
         if self.MedianFiltering:
@@ -125,7 +125,7 @@ class vmtkSurfaceCurvature(pypes.pypeScript):
                 values.sort()
                 if not values:
                     continue
-                medianValue = values[(len(values) - 1)/2]
+                medianValue = values[(len(values) - 1)//2]
                 activeScalars.SetTuple1(i,medianValue)
 
         if self.BoundedReciprocal:


### PR DESCRIPTION
Division operator returns floating-point value in Python3, while an integer value in Python2.
Fixed by using integer division operator (//) when the result is used an index.

fixes #362