### PR TITLE
Fix deprecated numpy issubdtype calls

### DIFF
--- a/vmtkScripts/contrib/vmtknumpytoimage.py
+++ b/vmtkScripts/contrib/vmtknumpytoimage.py
@@ -74,7 +74,7 @@ class vmtkNumpyToImage(pypes.pypeScript):
             if np.issubdtype(self.ArrayDict['PointData'][pointKey].dtype, np.floating):
                 pointDataArrayType = vtk.VTK_FLOAT
             else:
-                for checkDt in [int, np.uint8, np.uint16, np.uint32, np.uint64]:
+                for checkDt in [np.integer, np.uint8, np.uint16, np.uint32, np.uint64]:
                     if np.issubdtype(self.ArrayDict['PointData'][pointKey].dtype, checkDt):
                         pointDataArrayType = vtk.VTK_INT
                         break

--- a/vmtkScripts/contrib/vmtknumpytosurface.py
+++ b/vmtkScripts/contrib/vmtknumpytosurface.py
@@ -59,10 +59,10 @@ class vmtkNumpyToSurface(pypes.pypeScript):
         self.PrintLog('converting numpy array to surface')
         for pointKey in self.ArrayDict['PointData'].keys():
 
-            if np.issubdtype(self.ArrayDict['PointData'][pointKey].dtype, float):
+            if np.issubdtype(self.ArrayDict['PointData'][pointKey].dtype, np.floating):
                 pointDataArray = vtk.vtkFloatArray()
             else:
-                for checkDt in [int, np.uint8, np.uint16, np.uint32, np.uint64]:
+                for checkDt in [np.integer, np.uint8, np.uint16, np.uint32, np.uint64]:
                     if np.issubdtype(self.ArrayDict['PointData'][pointKey].dtype, checkDt):
                         pointDataArray = vtk.vtkIntArray()
                         break
@@ -109,9 +109,9 @@ class vmtkNumpyToSurface(pypes.pypeScript):
 
             else:
 
-                if np.issubdtype(self.ArrayDict['CellData'][cellKey].dtype, float):
+                if np.issubdtype(self.ArrayDict['CellData'][cellKey].dtype, np.floating):
                     cellDataArray = vtk.vtkFloatArray()
-                if np.issubdtype(self.ArrayDict['CellData'][cellKey].dtype, int):
+                if np.issubdtype(self.ArrayDict['CellData'][cellKey].dtype, np.integer):
                     cellDataArray = vtk.vtkIntArray()
 
                 try:


### PR DESCRIPTION
np.issubdtype with int or float second argument was deprecated in numpy 1.14 (https://github.com/numpy/numpy/pull/9505). This changes the argument to np.integer or np.floating which should avoid issues with recent numpy versions.