### PR TITLE
fix: make test data submodule init optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,8 @@ option( VMTK_BUILD_TESTING
   "Build the VMTK testing libraries" OFF)
 
 if(VMTK_BUILD_TESTING)
+  option( VMTK_INIT_TEST_DATA
+    "Initialize the vmtk-test-data submodule" ON)
   add_subdirectory(tests)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,8 +102,6 @@ option( VMTK_BUILD_TESTING
   "Build the VMTK testing libraries" OFF)
 
 if(VMTK_BUILD_TESTING)
-  option( VMTK_INIT_TEST_DATA
-    "Initialize the vmtk-test-data submodule" ON)
   add_subdirectory(tests)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,8 +12,10 @@ foreach (SCRIPT_FILE ${VMTK_TESTING_INIT_SRC})
   configure_file(${VMTK_TESTING_SOURCE_DIR}/${SCRIPT_FILE} ${VMTK_TESTING_INSTALL_LIB_DIR}/${SCRIPT_FILE} COPYONLY)
 endforeach ()
 
-execute_process(COMMAND git submodule update --init -- ${VMTK_TESTING_SOURCE_DIR}/vmtk-test-data
-                WORKING_DIRECTORY ${VMTK_TESTING_SOURCE_DIR})
+if(VMTK_INIT_TEST_DATA)
+  execute_process(COMMAND git submodule update --init -- ${VMTK_TESTING_SOURCE_DIR}/vmtk-test-data
+                  WORKING_DIRECTORY ${VMTK_TESTING_SOURCE_DIR})
+endif()
 
 if(NOT VMTK_TESTING_DATA_INSTALL_LIB_DIR)
   set(VMTK_TESTING_DATA_INSTALL_LIB_DIR ${CMAKE_BINARY_DIR}/tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,8 +12,24 @@ foreach (SCRIPT_FILE ${VMTK_TESTING_INIT_SRC})
   configure_file(${VMTK_TESTING_SOURCE_DIR}/${SCRIPT_FILE} ${VMTK_TESTING_INSTALL_LIB_DIR}/${SCRIPT_FILE} COPYONLY)
 endforeach ()
 
-if(VMTK_INIT_TEST_DATA)
-  execute_process(COMMAND git submodule update --init -- ${VMTK_TESTING_SOURCE_DIR}/vmtk-test-data
+# Check if submodule is clean
+execute_process(
+  COMMAND ${GIT_EXECUTABLE} status --porcelain ${VMTK_TESTING_SOURCE_DIR}/vmtk-test-data
+  WORKING_DIRECTORY ${VMTK_TESTING_SOURCE_DIR}
+  RESULT_VARIABLE error_code
+  OUTPUT_VARIABLE repo_status
+)
+if(error_code)
+  message(FATAL_ERROR "Failed to get the status")
+endif()
+
+string(LENGTH "${repo_status}" unclean_status)
+
+# If not in clean state do not overwrite
+if(unclean_status)
+  message(WARNING "Test data repo in unclean state, will not overwrite test data")
+else()
+  execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init -- ${VMTK_TESTING_SOURCE_DIR}/vmtk-test-data
                   WORKING_DIRECTORY ${VMTK_TESTING_SOURCE_DIR})
 endif()
 


### PR DESCRIPTION
Make `submodule init` optional so test data can be selected or edited without overwrite during build process.