### PR TITLE
STYLE: pep8 fixes

### DIFF
--- a/tests/test_vmtkScripts/test_vmtkcenterlines.py
+++ b/tests/test_vmtkScripts/test_vmtkcenterlines.py
@@ -52,6 +52,7 @@ def test_profileidlist_centerlines(aorta_surface_openends, compare_centerlines):
 
     assert compare_centerlines(centerliner.Centerlines, name) == True
 
+
 def test_profileidlist_centerlines_smooth(aorta_surface_openends, compare_centerlines):
     # centerlines don't change but voronoi diagram does
     # this test verifies that simplification runs without

--- a/tests/test_vmtkScripts/test_vmtkimagefeatures.py
+++ b/tests/test_vmtkScripts/test_vmtkimagefeatures.py
@@ -32,6 +32,7 @@ def test_features_types(aorta_image, compare_images, featureType, paramid, write
 
     assert compare_images(featurer.Image, name) == True
 
+
 @pytest.mark.parametrize("featureType,paramid", [
     ("upwind", '2'),
 ])
@@ -43,6 +44,7 @@ def test_features_types_upwind(aorta_image, compare_images, featureType, paramid
     featurer.Execute()
 
     assert compare_images(featurer.Image, name) == True
+
 
 @pytest.mark.parametrize("featureType,paramid", [
     ("gradient", '0'),
@@ -56,6 +58,7 @@ def test_sigmoid_on_for_gradient(aorta_image, compare_images, featureType, param
     featurer.Execute()
 
     assert compare_images(featurer.Image, name) == True
+
 
 @pytest.mark.parametrize("featureType,paramid", [
     ("upwind", '1'),


### PR DESCRIPTION
used script to catch fixes.

`$ for f in $(find . | ack "\.py$"); do \
  echo $f; \
  autopep8 --select W291,W292,W293,W391,E301,E302,E303,E304,E305,E306 --in-place $f; \
done`