### PR TITLE
feat: add wavefront reader/writer .obj extension

### DIFF
--- a/vmtkScripts/vmtksurfacereader.py
+++ b/vmtkScripts/vmtksurfacereader.py
@@ -35,7 +35,7 @@ class vmtkSurfaceReader(pypes.pypeScript):
         self.SetScriptName('vmtksurfacereader')
         self.SetScriptDoc('read a surface and store it in a vtkPolyData object')
         self.SetInputMembers([
-            ['Format','f','str',1,'["vtkxml","vtk","stl","ply","tecplot"]','file format'],
+            ['Format','f','str',1,'["vtkxml","vtk","stl","ply","tecplot", "wavefront"]','file format'],
             ['GuessFormat','guessformat','bool',1,'','guess file format from extension'],
             ['Surface','i','vtkPolyData',1,'','the input surface'],
             ['InputFileName','ifile','str',1,'','input file name']
@@ -179,6 +179,15 @@ class vmtkSurfaceReader(pypes.pypeScript):
 ##             cellIds.InsertNextId(int(splitLine[2])-1)
 ##             cells.InsertNextCell(cellIds)
 
+    def ReadOBJSurfaceFile(self):
+        if (self.InputFileName == ''):
+            self.PrintError('Error: no InputFileName.')
+        self.PrintLog('Reading wavefront surface file.')
+        reader = vtk.vtkOBJReader()
+        reader.SetFileName(self.InputFileName)
+        reader.Update()
+        self.Surface = reader.GetOutput()
+
     def Execute(self):
 
         extensionFormats = {'vtp':'vtkxml',
@@ -187,7 +196,8 @@ class vmtkSurfaceReader(pypes.pypeScript):
                             'stl':'stl',
                             'ply':'ply',
                             'tec':'tecplot',
-                            'dat':'tecplot'}
+                            'dat':'tecplot',
+                            'obj':'wavefront'}
 
         if self.InputFileName == 'BROWSER':
             import tkinter.filedialog
@@ -200,7 +210,7 @@ class vmtkSurfaceReader(pypes.pypeScript):
 
         if self.GuessFormat and self.InputFileName and not self.Format:
             import os.path
-            extension = os.path.splitext(self.InputFileName)[1]
+            extension = os.path.splitext(self.InputFileName)[1].lower()
             if extension:
                 extension = extension[1:]
                 if extension in list(extensionFormats.keys()):
@@ -216,6 +226,8 @@ class vmtkSurfaceReader(pypes.pypeScript):
             self.ReadPLYSurfaceFile()
         elif (self.Format == 'tecplot'):
             self.ReadTecplotSurfaceFile()
+        elif (self.Format == 'wavefront'):
+            self.ReadOBJSurfaceFile()
         else:
             self.PrintError('Error: unsupported format '+ self.Format + '.')
 


### PR DESCRIPTION
Update the surface reader and writer to work with wavefront obj format.

vtk can now write ascii wavefront format "obj", https://gitlab.kitware.com/vtk/vtk/merge_requests/4045
adding obj format to writer for when vtk version gets updated, currently won't work unless vtk master is linked to vmtk. (not in latest vtk release 8.1.1) will give an error message if vtk version is less than 9 for now.

vtk could already read wavefront format so that portion already works.

also making sure the extension of the file is compared in lower case. I have seen ".PLY", ".OBJ", and "STL" in the wild.

I believe this addresses the comments in #297 although I flubbed getting git to do what I wanted.