### PR TITLE
BUG: Fix initial seam array value never assigned

### DIFF
--- a/vtkVmtk/Misc/vtkvmtkTopologicalSeamFilter.cxx
+++ b/vtkVmtk/Misc/vtkvmtkTopologicalSeamFilter.cxx
@@ -182,6 +182,7 @@ int vtkvmtkTopologicalSeamFilter::RequestData(vtkInformation *vtkNotUsed(request
     seamQueue.pop();
     double point0Value = sourceArray->GetTuple1(point0Id);
     visitedArray->SetValue(point0Id,1);
+    seamArray->SetValue(point0Id,point0Value);
     input->GetPointCells(point0Id,ncells,cells);
     for (vtkIdType i=0; i<ncells; i++)
     {


### PR DESCRIPTION
Set `seamArray` value for the first element of the recursive loop instead of keeping the initialization value of 0.0 in `vtkvmtkTopologicalSeamFilter.cxx`

This should solve the extra triangle remaining issue with the `vmtksurfaceendclipper` script (#169). The initialization value of 0.0 for this specific point (top of the extra triangle) makes the clipping filter believe it belongs to the clipping plane resulting in an uncut triangle

Associated post on VMTK forum: https://discourse.slicer.org/t/extra-or-missing-triangle-with-vmtksurfaceendclipper-script/20530