### PR TITLE
Set random seed for non-deterministic test

### DIFF
--- a/tests/test_vmtkScripts/test_vmtkcenterlinesnetwork.py
+++ b/tests/test_vmtkScripts/test_vmtkcenterlinesnetwork.py
@@ -16,11 +16,12 @@
 
 import pytest
 import vmtk.vmtkcenterlinesnetwork as centerlinesnetwork
-
+import random
 
 def test_centerline_extraction_surface_with_no_hole(aorta_surface):
     clnetwork = centerlinesnetwork.vmtkCenterlinesNetwork()
     clnetwork.Surface = aorta_surface
+    random.seed(42)
     clnetwork.Execute()
     centerlines = clnetwork.Centerlines
     assert (centerlines.GetNumberOfPoints() > 100) == True

--- a/tests/test_vmtkScripts/test_vmtkcenterlinesnetwork.py
+++ b/tests/test_vmtkScripts/test_vmtkcenterlinesnetwork.py
@@ -16,12 +16,12 @@
 
 import pytest
 import vmtk.vmtkcenterlinesnetwork as centerlinesnetwork
-import random
+
 
 def test_centerline_extraction_surface_with_no_hole(aorta_surface):
     clnetwork = centerlinesnetwork.vmtkCenterlinesNetwork()
     clnetwork.Surface = aorta_surface
-    random.seed(42)
+    clnetwork.RandomSeed = 42
     clnetwork.Execute()
     centerlines = clnetwork.Centerlines
     assert (centerlines.GetNumberOfPoints() > 100) == True

--- a/vmtkScripts/vmtkcenterlinesnetwork.py
+++ b/vmtkScripts/vmtkcenterlinesnetwork.py
@@ -88,7 +88,8 @@ class vmtkCenterlinesNetwork(pypes.pypeScript):
         self.DelaunayTessellation = None
         self.VoronoiDiagram = None
         self.PoleIds = None
-
+        self.RandomSeed = None
+        
         self.vmtkRenderer = None
         self.OwnRenderer = 0
 
@@ -107,7 +108,8 @@ class vmtkCenterlinesNetwork(pypes.pypeScript):
             ['CostFunctionArrayName','costfunctionarray','str',1],
             ['DelaunayTessellation','delaunaytessellation','vtkUnstructuredGrid',1,'','','vmtkmeshwriter'],
             ['VoronoiDiagram','voronoidiagram','vtkPolyData',1,'','','vmtksurfacewriter'],
-            ['PoleIds','poleids','vtkIdList',1]])
+            ['PoleIds','poleids','vtkIdList',1],
+            ['RandomSeed','randomseed','int',1])
 
     def Execute(self):
         if self.Surface == None:
@@ -137,7 +139,10 @@ class vmtkCenterlinesNetwork(pypes.pypeScript):
         # randomly select one cell to delete so that there is an opening for
         # vmtkNetworkExtraction to use.
         numCells = networkSurface.GetNumberOfCells()
-        cellToDelete = random.randrange(0, numCells-1)
+        random_generator = random.Random()
+        if self.RandomSeed is not None:
+            random_generator.seed(self.RandomSeed)
+        cellToDelete = random_generator.randrange(0, numCells-1)
         networkSurface.BuildLinks()
         networkSurface.DeleteCell(cellToDelete)
         networkSurface.RemoveDeletedCells()


### PR DESCRIPTION
The behavior of `vmtkcenterlinesnetwork.py` is not deterministic since this script chooses a random node through python's `random` module, which means builds can randomly fail because of this one test. I think the easiest for now would be to use the same random seed for all builds, hopefully this at least makes sure the behavior is consistent.

(Technically different python versions can affect the random generator, but as far as I can tell it has been stable since python [3.2](https://stackoverflow.com/questions/11929701/why-is-seeding-the-random-generator-not-stable-between-versions-of-python))