### PR TITLE
Add CMake option to not expect test data to be a git repository

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,11 @@ endif()
 option( VMTK_USE_SUPERBUILD
   "Build VMTK and the projects it depends on via SuperBuild.cmake." ON )
 
+option( VMTK_TEST_SUBMODULE
+  "Check and update VMTK Test data repository" ON )
+
 # Git setup
-if (VMTK_USE_SUPERBUILD OR VMTK_BUILD_TESTING)
+if (VMTK_USE_SUPERBUILD OR VMTK_TEST_SUBMODULE)
   if( NOT GIT_EXECUTABLE )
     find_package( Git REQUIRED )
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,8 @@ endif()
 option( VMTK_USE_SUPERBUILD
   "Build VMTK and the projects it depends on via SuperBuild.cmake." ON )
 
-set(VMTK_TEST_DATA_SOURCE "git-submodule" CACHE STRING "How to download test data (none, git-submodule)" FORCE)
-set_property(CACHE VMTK_TEST_DATA_SOURCE PROPERTY STRINGS none git-submodule)
+set(VMTK_TEST_DATA_SOURCE "git-submodule" CACHE STRING "git-submodule initializes the vmtk-test-data repository. in-place assumes test data is already available." FORCE)
+set_property(CACHE VMTK_TEST_DATA_SOURCE PROPERTY STRINGS in-place git-submodule)
 
 # Git setup
 if (VMTK_USE_SUPERBUILD OR VMTK_TEST_DATA_SOURCE MATCHES "git-submodule")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,11 +85,11 @@ endif()
 option( VMTK_USE_SUPERBUILD
   "Build VMTK and the projects it depends on via SuperBuild.cmake." ON )
 
-option( VMTK_TEST_SUBMODULE
-  "Check and update VMTK Test data repository" ON )
+set(VMTK_TEST_DATA_SOURCE "git-submodule" CACHE STRING "How to download test data (none, git-submodule)" FORCE)
+
 
 # Git setup
-if (VMTK_USE_SUPERBUILD OR VMTK_TEST_SUBMODULE)
+if (VMTK_USE_SUPERBUILD OR VMTK_TEST_DATA_SOURCE MATCHES "git-submodule")
   if( NOT GIT_EXECUTABLE )
     find_package( Git REQUIRED )
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ option( VMTK_USE_SUPERBUILD
   "Build VMTK and the projects it depends on via SuperBuild.cmake." ON )
 
 set(VMTK_TEST_DATA_SOURCE "git-submodule" CACHE STRING "How to download test data (none, git-submodule)" FORCE)
-
+set_property(CACHE VMTK_TEST_DATA_SOURCE PROPERTY STRINGS none git-submodule)
 
 # Git setup
 if (VMTK_USE_SUPERBUILD OR VMTK_TEST_DATA_SOURCE MATCHES "git-submodule")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,7 +12,7 @@ foreach (SCRIPT_FILE ${VMTK_TESTING_INIT_SRC})
   configure_file(${VMTK_TESTING_SOURCE_DIR}/${SCRIPT_FILE} ${VMTK_TESTING_INSTALL_LIB_DIR}/${SCRIPT_FILE} COPYONLY)
 endforeach ()
 
-if (VMTK_TEST_SUBMODULE)
+if (VMTK_TEST_DATA_SOURCE MATCHES "git-submodule")
   # Check if submodule is clean
   execute_process(
     COMMAND ${GIT_EXECUTABLE} status --porcelain ${VMTK_TESTING_SOURCE_DIR}/vmtk-test-data

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,26 +12,30 @@ foreach (SCRIPT_FILE ${VMTK_TESTING_INIT_SRC})
   configure_file(${VMTK_TESTING_SOURCE_DIR}/${SCRIPT_FILE} ${VMTK_TESTING_INSTALL_LIB_DIR}/${SCRIPT_FILE} COPYONLY)
 endforeach ()
 
-# Check if submodule is clean
-execute_process(
-  COMMAND ${GIT_EXECUTABLE} status --porcelain ${VMTK_TESTING_SOURCE_DIR}/vmtk-test-data
-  WORKING_DIRECTORY ${VMTK_TESTING_SOURCE_DIR}
-  RESULT_VARIABLE error_code
-  OUTPUT_VARIABLE repo_status
-)
-if(error_code)
-  message(FATAL_ERROR "Failed to get the status")
+if (VMTK_TEST_SUBMODULE)
+  # Check if submodule is clean
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} status --porcelain ${VMTK_TESTING_SOURCE_DIR}/vmtk-test-data
+    WORKING_DIRECTORY ${VMTK_TESTING_SOURCE_DIR}
+    RESULT_VARIABLE error_code
+    OUTPUT_VARIABLE repo_status
+  )
+  if(error_code)
+    message(FATAL_ERROR "Failed to get the status")
+  endif()
+
+  string(LENGTH "${repo_status}" unclean_status)
+
+  # If not in clean state do not overwrite
+  if(unclean_status)
+    message(WARNING "Test data repo in unclean state, will not overwrite test data")
+  else()
+    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init -- ${VMTK_TESTING_SOURCE_DIR}/vmtk-test-data
+            WORKING_DIRECTORY ${VMTK_TESTING_SOURCE_DIR})
+  endif()
 endif()
 
-string(LENGTH "${repo_status}" unclean_status)
 
-# If not in clean state do not overwrite
-if(unclean_status)
-  message(WARNING "Test data repo in unclean state, will not overwrite test data")
-else()
-  execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init -- ${VMTK_TESTING_SOURCE_DIR}/vmtk-test-data
-                  WORKING_DIRECTORY ${VMTK_TESTING_SOURCE_DIR})
-endif()
 
 if(NOT VMTK_TESTING_DATA_INSTALL_LIB_DIR)
   set(VMTK_TESTING_DATA_INSTALL_LIB_DIR ${CMAKE_BINARY_DIR}/tests)


### PR DESCRIPTION
CMake always tries to initialize the test data submodule, which can cause problems if I'm trying to build form a tarball or if git isn't available etc but still want the tests to run. 
This adds a `VMTK_TEST_SUBMODULE` option to disable this (defaults to replicating the existing behaviour)