### PR TITLE
COMP: Fix build error on Windows

### DIFF
--- a/vtkVmtk/Segmentation/itkAnisotropicDiffusionVesselEnhancementImageFilter.h
+++ b/vtkVmtk/Segmentation/itkAnisotropicDiffusionVesselEnhancementImageFilter.h
@@ -227,7 +227,13 @@ private:
     AnisotropicDiffusionVesselEnhancementImageFilter *Filter;
     TimeStepType TimeStep;
     std::vector< TimeStepType > TimeStepList;
+#if ITK_VERSION_MAJOR > 5 || (ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR >= 3)
+    // ResolveTimeStep argument type was changed to uint_8_t in ITK-5.3.
+    // https://github.com/InsightSoftwareConsortium/ITK/commit/b66133ab53369bdf265348c0c31cfa6451b53934
+    std::vector< uint8_t > ValidTimeStepList;
+#else
     std::vector< bool > ValidTimeStepList;
+#endif
   };
 
   //struct DenseFDThreadStruct


### PR DESCRIPTION
Build failed using MSVC due to inconsistent use of bool and uint_8 (see error message below). Considered using both `itk::uint8_t`, but chose to go with `uint8_t` instead as this type was already used in VMTK.

```
7>------ Build started: Project: vtkvmtkSegmentation, Configuration: Release x64 ------
7>vtkvmtkVesselEnhancingDiffusionImageFilter.cxx
7>C:\D\SlicerExtension-VMTK_R\VMTK\vtkVmtk\Segmentation\itkAnisotropicDiffusionVesselEnhancementImageFilter.txx(409,1): error C2664: 'double itk::FiniteDifferenceImageFilter<TInputImage,TOutputImage>::ResolveTimeStep(const std::vector<double,std::allocator<double>> &,const std::vector<itk::uint8_t,std::allocator<itk::uint8_t>> &) const': cannot convert argument 2 from 'std::vector<bool,std::allocator<bool>>' to 'const std::vector<itk::uint8_t,std::allocator<itk::uint8_t>> &'
7>        with
7>        [
7>            TInputImage=ImageType,
7>            TOutputImage=ImageType
7>        ]
7>C:\D\SlicerExtension-VMTK_R\VMTK\vtkVmtk\Segmentation\itkAnisotropicDiffusionVesselEnhancementImageFilter.txx(409,1): message : Reason: cannot convert from 'std::vector<bool,std::allocator<bool>>' to 'const std::vector<itk::uint8_t,std::allocator<itk::uint8_t>>'
7>C:\D\SlicerExtension-VMTK_R\VMTK\vtkVmtk\Segmentation\itkAnisotropicDiffusionVesselEnhancementImageFilter.txx(409,51): message : No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
7>C:\D\S4R\ITK\Modules\Core\FiniteDifference\include\itkFiniteDifferenceImageFilter.h(338,3): message : see declaration of 'itk::FiniteDifferenceImageFilter<TInputImage,TOutputImage>::ResolveTimeStep'
7>        with
7>        [
7>            TInputImage=ImageType,
7>            TOutputImage=ImageType
7>        ]
7>C:\D\SlicerExtension-VMTK_R\VMTK\vtkVmtk\Segmentation\itkAnisotropicDiffusionVesselEnhancementImageFilter.txx(381): message : while compiling class template member function 'double itk::AnisotropicDiffusionVesselEnhancementImageFilter<ImageType,ImageType,itk::HessianSmoothed3DToVesselnessMeasureImageFilter<double>>::CalculateChange(void)'
7>C:\D\SlicerExtension-VMTK_R\VMTK\vtkVmtk\Segmentation\itkAnisotropicDiffusionVesselEnhancementImageFilter.txx(627): message : see reference to function template instantiation 'double itk::AnisotropicDiffusionVesselEnhancementImageFilter<ImageType,ImageType,itk::HessianSmoothed3DToVesselnessMeasureImageFilter<double>>::CalculateChange(void)' being compiled
7>C:\D\SlicerExtension-VMTK_R\VMTK\vtkVmtk\Segmentation\vtkvmtkVesselEnhancingDiffusionImageFilter.cxx(64): message : see reference to class template instantiation 'itk::AnisotropicDiffusionVesselEnhancementImageFilter<ImageType,ImageType,itk::HessianSmoothed3DToVesselnessMeasureImageFilter<double>>' being compiled
7>Done building project "vtkvmtkSegmentation.vcxproj" -- FAILED.
```