### PR TITLE
COMP: Fix build with latest VTK master

### DIFF
--- a/vtkVmtk/Misc/CMakeLists.txt
+++ b/vtkVmtk/Misc/CMakeLists.txt
@@ -1,5 +1,20 @@
 set(VTK_VMTK_MISC_TARGET_LINK_LIBRARIES vtkvmtkComputationalGeometry vtkvmtkDifferentialGeometry)
 
+# Linking of try_compile fails due to some obscure reason.
+# Since for us here is enough to test compilation, we disable linking
+# instead of spending time with trying to resolve the linking issue.
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+try_compile(_VTK_HAS_VTKINTERVALINFORMATION
+  "${CMAKE_CURRENT_BINARY_DIR}/CMakeTmp"
+  SOURCES "${CMAKE_CURRENT_LIST_DIR}/vtkvmtkTestIntervalInformation.cxx"
+  LINK_LIBRARIES ${VTK_LIBRARIES}
+  OUTPUT_VARIABLE _VTK_HAS_VTKINTERVALINFORMATION_OUTPUT)
+mark_as_advanced(_VTK_HAS_VTKINTERVALINFORMATION)
+
+if (NOT _VTK_HAS_VTKINTERVALINFORMATION)
+  add_definitions (-DVMTK_USE_LEGACY_INTERVAL_INFORMATION)
+endif()
+
 set( VTK_VMTK_MISC_COMPONENTS
   ${VTK_COMPONENT_PREFIX}FiltersFlowPaths
   ${VTK_COMPONENT_PREFIX}FiltersGeometry

--- a/vtkVmtk/Misc/vtkvmtkStaticTemporalStreamTracer.cxx
+++ b/vtkVmtk/Misc/vtkvmtkStaticTemporalStreamTracer.cxx
@@ -37,6 +37,12 @@ PURPOSE.  See the above copyright notice for more information.
 vtkStandardNewMacro(vtkvmtkStaticTemporalStreamTracer);
 vtkCxxSetObjectMacro(vtkvmtkStaticTemporalStreamTracer, TimeStepsTable, vtkTable);
 
+#if VMTK_USE_LEGACY_INTERVAL_INFORMATION
+  #define vmtkIntervalInformation IntervalInformation
+#else
+  #define vmtkIntervalInformation vtkIntervalInformation
+#endif
+
 vtkvmtkStaticTemporalStreamTracer::vtkvmtkStaticTemporalStreamTracer()
 {
   this->SeedTime = 0.0;
@@ -464,10 +470,10 @@ void vtkvmtkStaticTemporalStreamTracer::Integrate(vtkDataSet *input0,
     // We will always pass an arc-length step size to the integrator.
     // If the user specifies a step size in cell length unit, we will
     // have to convert it to arc length.
-    IntervalInformation stepSize;  // either positive or negative
+    vmtkIntervalInformation stepSize;  // either positive or negative
     stepSize.Unit  = LENGTH_UNIT;
     stepSize.Interval = 0;
-    IntervalInformation aStep; // always positive
+    vmtkIntervalInformation aStep; // always positive
     aStep.Unit = LENGTH_UNIT;
     double step, minStep=0, maxStep=0;
     double stepTaken, accumTime=startTime;
@@ -566,11 +572,19 @@ void vtkvmtkStaticTemporalStreamTracer::Integrate(vtkDataSet *input0,
         aStep.Interval = this->MaximumPropagation - propagation;
         if ( stepSize.Interval >= 0 )
           {
+#if VMTK_USE_LEGACY_INTERVAL_INFORMATION
           stepSize.Interval = this->ConvertToLength( aStep, cellLength );
+#else
+          stepSize.Interval = vtkIntervalInformation::ConvertToLength(aStep, cellLength);
+#endif
           }
         else
           {
-          stepSize.Interval = this->ConvertToLength( aStep, cellLength ) * ( -1.0 );
+#if VMTK_USE_LEGACY_INTERVAL_INFORMATION
+          stepSize.Interval = this->ConvertToLength(aStep, cellLength) * (-1.0);
+#else
+          stepSize.Interval = vtkIntervalInformation::ConvertToLength(aStep, cellLength) * (-1.0);
+#endif
           }
         maxStep = stepSize.Interval;
         }

--- a/vtkVmtk/Misc/vtkvmtkTestIntervalInformation.cxx
+++ b/vtkVmtk/Misc/vtkvmtkTestIntervalInformation.cxx
@@ -1,0 +1,14 @@
+// IntervalInformation protected member was renamed to a publicly available
+// vtkIntervalInformation type on 2021-12-02 in
+// https://github.com/Kitware/VTK/commit/a30f2b14bb1bf088513d52e4eebda0b0ed6df08b
+
+// Compilation succeeds for modern VTK (that has vtkIntervalInformation)
+// and fails for legacy VTK (where IntervalInformation is only available as a protected struct).
+
+#include "vtkStreamTracer.h"
+
+int main()
+{
+  vtkIntervalInformation info;
+  return 0;
+}


### PR DESCRIPTION
A backward-incompatible change was introduced in public VTK API
(IntervalInformation was renamed to vtkIntervalInformation and other related changes).

The change was not associated with a VTK version change (not even patch), therefore a compile check was added
to detect what VTK version is used and make VMTK build correctly with both the latest VTK-9.1.0 and earlier versions.
