### PR TITLE
Add tests for undefined pypescript attributes

### DIFF
--- a/tests/test_vmtkScripts/CMakeLists.txt
+++ b/tests/test_vmtkScripts/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TEST_VMTKSCRIPTS_SRCS
     conftest.py
     test_importvmtkscripts.py
     test_importvtkvmtk.py
+    test_pypescripts.py
     test_vmtkbifurcationprofiles.py
     test_vmtkbifurcationreferencesystems.py
     test_vmtkbifurcationsections.py

--- a/tests/test_vmtkScripts/test_pypescripts.py
+++ b/tests/test_vmtkScripts/test_pypescripts.py
@@ -1,0 +1,33 @@
+## Program: VMTK
+## Language:  Python
+## Date:      February 12, 2018
+## Version:   1.4
+
+##   Copyright (c) Richard Izzo, Luca Antiga, All rights reserved.
+##   See LICENSE file for details.
+
+##      This software is distributed WITHOUT ANY WARRANTY; without even
+##      the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+##      PURPOSE.  See the above copyright notices for more information.
+
+## Note: this code was contributed by
+##       Ramtin Gharleghi (Github @ramtingh)
+##       University of New South Wales
+
+import pytest
+import inspect
+from vmtk import vmtkscripts, pypes
+
+scripts = []
+for script in vmtkscripts.__dict__.values():
+    if inspect.isclass(script) and issubclass(script, pypes.pypeScript):
+        scripts.append(script)
+
+@pytest.mark.parametrize("script",scripts)
+def test_vmtkpypescript(script):
+    obj = script()
+    missing = []
+    for member in obj.InputMembers:
+        if not hasattr(obj, member.MemberName):
+            missing.append(member.MemberName)
+    assert not missing

--- a/vmtkScripts/vmtkdistancetocenterlines.py
+++ b/vmtkScripts/vmtkdistancetocenterlines.py
@@ -36,7 +36,9 @@ class vmtkDistanceToCenterlines(pypes.pypeScript):
         self.ProjectPointArrays = 0
         self.DistanceToCenterlinesArrayName = 'DistanceToCenterlines'
         self.RadiusArrayName = 'MaximumInscribedSphereRadius'
-
+        self.UseRadiusThreshold = False
+        self.RadiusThreshold = 1.0
+        
         self.SetScriptName('vmtkdistancetocenterlines')
         self.SetScriptDoc('calculate the minimum euclidian from surface points to a centerline')
         self.SetInputMembers([


### PR DESCRIPTION
pypeScripts declare command line options via SetInputMembers and expect these to be initialized separately, otherwise the command line version will fail while python bindings work fine (e.g. ` vmtkdistancetocenterlines ` in https://github.com/vmtk/vmtk/issues/425#issuecomment-1124520347) 
This test should catch this sort of issues