### PR TITLE
COMP: Remove deprecated/removed std::binary_function

### DIFF
--- a/vtkVmtk/Segmentation/itkMedialCurveImageFilter.h
+++ b/vtkVmtk/Segmentation/itkMedialCurveImageFilter.h
@@ -121,7 +121,7 @@ class ITK_EXPORT MedialCurveImageFilter:
 				InputPixelType GetValue() {return pixelValue;};
 		};
 
-		struct Greater:public std::binary_function<Pixel, Pixel, bool>
+		struct Greater
 		{
 			public:
 				bool operator()(const Pixel &p1, const Pixel &p2)  const


### PR DESCRIPTION
std::binary_function was deprecated in C++11 and removed in C++17.
It only added typedefs. Since they were unused, it compiles fine
without them.

See: https://github.com/InsightSoftwareConsortium/ITK/commit/7b2dfd28d415d33c0138db275974735a9015fb30

binary_function is breaking the windows build on the Slicer extension factory now that we have switched to C++ 17, see:
https://slicer.cdash.org/viewBuildError.php?buildid=2733792


When this is merged, will update Slicer extension.