### PR TITLE
Fix compilation bug related to vtk9.2.x api change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 .cache
 .DS_Store
 .vscode
+build*

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataLineEmbedder.cxx
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataLineEmbedder.cxx
@@ -74,7 +74,7 @@ vtkIdType vtkvmtkPolyDataLineEmbedder::GetCellId(vtkPolyData* input, vtkIdList* 
       }
     else
       {
-      cellIds->IntersectWith(*neighborCellIds);
+      cellIds->IntersectWith(neighborCellIds);
       }
     }  
 

--- a/vtkVmtk/Contrib/vtkvmtkBoundaryLayerGenerator2.cxx
+++ b/vtkVmtk/Contrib/vtkvmtkBoundaryLayerGenerator2.cxx
@@ -402,7 +402,7 @@ int vtkvmtkBoundaryLayerGenerator2::RequestData(
                   {
                   tetraPtsList->InsertNextId(tetraPts[l]);
                   }
-                tetraPtsList->IntersectWith(*openProfilePts);
+                tetraPtsList->IntersectWith(openProfilePts);
                 //If this tetrahedra has a face on the extruded open profile, include it
                 if (tetraPtsList->GetNumberOfIds() == 3)
                   {

--- a/vtkVmtk/Contrib/vtkvmtkDolfinWriter2.cxx
+++ b/vtkVmtk/Contrib/vtkvmtkDolfinWriter2.cxx
@@ -201,7 +201,7 @@ void vtkvmtkDolfinWriter2::WriteData()
           vtkCell* face = cell->GetFace(k);
           vtkIdList* matchingPointIds = vtkIdList::New();
           matchingPointIds->DeepCopy(face->GetPointIds());
-          matchingPointIds->IntersectWith(*faceCellPoints);
+          matchingPointIds->IntersectWith(faceCellPoints);
           int numberOfNonMatching = face->GetNumberOfPoints() - matchingPointIds->GetNumberOfIds();
           matchingPointIds->Delete();
 

--- a/vtkVmtk/IO/vtkvmtkXdaWriter.cxx
+++ b/vtkVmtk/IO/vtkvmtkXdaWriter.cxx
@@ -340,7 +340,7 @@ void vtkvmtkXdaWriter::WriteData()
         vtkIdList* matchingPointIds = vtkIdList::New();
         matchingPointIds->DeepCopy(face->GetPointIds());
 
-        matchingPointIds->IntersectWith(*faceCellPoints);
+        matchingPointIds->IntersectWith(faceCellPoints);
         
         int numberOfNonMatching = face->GetNumberOfPoints() - matchingPointIds->GetNumberOfIds();
 

--- a/vtkVmtk/Misc/CMakeLists.txt
+++ b/vtkVmtk/Misc/CMakeLists.txt
@@ -55,8 +55,8 @@ set (VTK_VMTK_MISC_SRCS
   vtkvmtkRBFInterpolation.cxx
   vtkvmtkSimpleCapPolyData.cxx
   vtkvmtkSmoothCapPolyData.cxx
-  vtkvmtkStaticTemporalInterpolatedVelocityField.cxx
-  vtkvmtkStaticTemporalStreamTracer.cxx
+  # vtkvmtkStaticTemporalInterpolatedVelocityField.cxx
+  # vtkvmtkStaticTemporalStreamTracer.cxx
   vtkvmtkStreamlineClusteringFilter.cxx
   vtkvmtkStreamlineOsculatingCentersFilter.cxx
   vtkvmtkStreamlineToParticlesFilter.cxx


### PR DESCRIPTION
1. `vtkIdList::IntersectWith(vtkIdList& otherIds)`  was dropped since vtk 9.2.0.rc1(https://github.com/Kitware/VTK/commit/e6ce038572cc62ec83ba0e56af7cae8aca7893b4)

2. `vtkvmtkStaticTemporalInterpolatedVelocityField.cxx` has several incompatible API calls to `vtkInterpolatedVelocityField` and couldn't fix easily