### PR TITLE
ENH: Add ITK and VTK to buildtree VMTKConfig.cmake

### DIFF
--- a/CMake/VMTKConfig.cmake.in
+++ b/CMake/VMTKConfig.cmake.in
@@ -30,3 +30,10 @@ set(VMTK_LIBRARY_DIRS "@VMTK_BINARY_DIR@/bin")
 set(VMTK_USE_FILE
   "@VMTK_BINARY_DIR@/VMTKUse.cmake"
 )
+
+set(ITK_DIR @ITK_DIR@)
+find_package(ITK REQUIRED)
+include(${ITK_USE_FILE})
+
+set(VTK_DIR @VTK_DIR@)
+find_package(VTK REQUIRED)


### PR DESCRIPTION
This adds the corresponding `find_package` and `include` for the ITK and VTK used to build VMTK. This is helpful for developers which want to use tht VMTK build tree for building own applications.

Another option considered is to include the `find_package` and the `include` commands for ITK and VTK in the `VMTKUse.cmake` file instead of the `VMTKConfig.cmake` file

Yet another option could be to only set the `ITK_DIR` and `VTK_DIR` in either the `VMTKConfig.cmake` or the `VMTKUse.cmake` files and let the user explicitly do:

```
find(VMTK REQUIRED)
include(${VMTK_USE_FILE})

find(VTK REQUIRED) 
find(ITK REQUIRED)
include(${ITK_USE_FILE})
```

I wonder if finding ITK would also configure VTK (since ITK could have been configured to use the VMTK VTK already).

This closes vmtk/vmtk#448