### PR TITLE
Add missing attributes to vmtkdistancetocenterlines.py

### DIFF
--- a/vmtkScripts/vmtkdistancetocenterlines.py
+++ b/vmtkScripts/vmtkdistancetocenterlines.py
@@ -36,6 +36,9 @@ class vmtkDistanceToCenterlines(pypes.pypeScript):
         self.ProjectPointArrays = 0
         self.DistanceToCenterlinesArrayName = 'DistanceToCenterlines'
         self.RadiusArrayName = 'MaximumInscribedSphereRadius'
+        self.UseRadiusThreshold = 0
+        self.RadiusThreshold = 0.0
+
 
         self.SetScriptName('vmtkdistancetocenterlines')
         self.SetScriptDoc('calculate the minimum euclidian from surface points to a centerline')


### PR DESCRIPTION
Add `UseRadiusThreshold` and `RadiusThreshold` atributes to `vmtkdistancetocenterlines.py`.

Fixes following error when using `vmtkDistanceToCenterlines`:
```python
  File ".../vmtk/master/3j5eq5bfjj7uldmd/lib/python3.8/site-packages/vmtk/vmtkdistancetocenterlines.py", line 108, in Execute
    if (self.UseRadiusThreshold):
AttributeError: 'vmtkDistanceToCenterlines' object has no attribute 'UseRadiusThreshold'
```