### PR TITLE
Update vmtkmeshwriter.py

### DIFF
--- a/vmtkScripts/vmtkmeshwriter.py
+++ b/vmtkScripts/vmtkmeshwriter.py
@@ -264,7 +264,7 @@ class vmtkMeshWriter(pypes.pypeScript):
             xml = file.read()
             file.close()
             import gzip
-            gzfile = gzip.open(self.OutputFileName,'w')
+            gzfile = gzip.open(self.OutputFileName,'wt')
             gzfile.write(xml)
             gzfile.close()
 


### PR DESCRIPTION
Changed WriteDolfinMeshFile when writing a compressed mesh gzip in 1.12 does not automatically convert strings to bytes. changing the open mode to wt fixes this issue preventing "Expected a sequence of byes not a string" errors.