### PR TITLE
Include iostream to build against VTK 9.6

### DIFF
--- a/vtkVmtk/DifferentialGeometry/vtkvmtkPolyDataDiscreteElasticaFilter.cxx
+++ b/vtkVmtk/DifferentialGeometry/vtkvmtkPolyDataDiscreteElasticaFilter.cxx
@@ -30,6 +30,7 @@
 #include "vtkObjectFactory.h"
 #include "vtkVersion.h"
 
+#include <iostream>
 
 vtkStandardNewMacro(vtkvmtkPolyDataDiscreteElasticaFilter);
 
@@ -165,7 +166,7 @@ int vtkvmtkPolyDataDiscreteElasticaFilter::RequestData(
         }
 
 //      f = laplaceBeltramiH;
-//      cout<<laplaceBeltramiH<<" "<<meanCurvature<<" "<<gaussianCurvature<<" "<<f<<endl;
+//      std::cout<<laplaceBeltramiH<<" "<<meanCurvature<<" "<<gaussianCurvature<<" "<<f<<endl;
 //      f = - meanCurvature;
 
       deltaT = minTriangleArea*minTriangleArea / 1.0;
@@ -178,7 +179,7 @@ int vtkvmtkPolyDataDiscreteElasticaFilter::RequestData(
       newPoints->SetPoint(i,newPoint);
       }
 
-    cout<<deltaT<<endl;      
+    std::cout<<deltaT<<endl;      
 
     surface->GetPoints()->DeepCopy(newPoints);
     }
@@ -328,7 +329,7 @@ int vtkvmtkPolyDataDiscreteElasticaFilter::RequestData(
       newPoints->SetPoint(i,newPoint);
       }
 
-    cout<<deltaT<<endl;      
+    std::cout<<deltaT<<endl;      
 
     surface->GetPoints()->DeepCopy(newPoints);
     }
@@ -535,7 +536,7 @@ int vtkvmtkPolyDataDiscreteElasticaFilter::RequestData(
         }
 
 //      f = - meanCurvature;
-//      cout<<laplaceBeltramiH<<" "<<meanCurvature<<" "<<gaussianCurvature<<" "<<f<<endl;
+//      std::cout<<laplaceBeltramiH<<" "<<meanCurvature<<" "<<gaussianCurvature<<" "<<f<<endl;
 
       deltaT = minTriangleArea*minTriangleArea / 10.0;
 
@@ -546,7 +547,7 @@ int vtkvmtkPolyDataDiscreteElasticaFilter::RequestData(
       newPoints->SetPoint(i,newPoint);
       }
 
-    cout<<deltaT<<endl;      
+    std::cout<<deltaT<<endl;      
 
     surface->GetPoints()->DeepCopy(newPoints);
     }

--- a/vtkVmtk/DifferentialGeometry/vtkvmtkPolyDataSurfaceRemeshing.cxx
+++ b/vtkVmtk/DifferentialGeometry/vtkvmtkPolyDataSurfaceRemeshing.cxx
@@ -36,6 +36,7 @@
 #include "vtkObjectFactory.h"
 #include "vtkVersion.h"
 
+#include <iostream>
 
 vtkStandardNewMacro(vtkvmtkPolyDataSurfaceRemeshing);
 
@@ -311,7 +312,7 @@ int vtkvmtkPolyDataSurfaceRemeshing::RequestData(
   int relocationSuccess = RELOCATE_SUCCESS;
   for (int n=0; n<this->NumberOfIterations; n++)
     {
-    cout<<"Iteration "<<n+1<<"/"<<this->NumberOfIterations<<endl;
+    std::cout<<"Iteration "<<n+1<<"/"<<this->NumberOfIterations<<endl;
     this->EdgeCollapseIteration();
     this->EdgeFlipIteration();
     this->EdgeSplitIteration();
@@ -329,7 +330,7 @@ int vtkvmtkPolyDataSurfaceRemeshing::RequestData(
       }
     }
 
-  cout<<"Final mesh improvement"<<endl;
+  std::cout<<"Final mesh improvement"<<endl;
   bool projectToSurface = false;
   for (int i=0; i<this->NumberOfIterations; i++)
     {
@@ -1128,7 +1129,7 @@ int vtkvmtkPolyDataSurfaceRemeshing::SplitTriangle(vtkIdType cellId)
   vtkIdType cell2 = this->Mesh->InsertNextLinkedCell(VTK_TRIANGLE,3,tri);
   this->CellEntityIdsArray->InsertValue(cell2,cellEntityId);
 
-  //cout<<cell1<<" "<<cell2<<" "<<numberOfCells<<endl;
+  //std::cout<<cell1<<" "<<cell2<<" "<<numberOfCells<<endl;
 
   return SUCCESS;
 }
@@ -1668,7 +1669,7 @@ int vtkvmtkPolyDataSurfaceRemeshing::TestTriangleSplit(vtkIdType cellId)
     return DO_NOTHING;
     }
 
-  //cout<<cellId<<" "<<area<<" "<<targetArea<<endl;
+  //std::cout<<cellId<<" "<<area<<" "<<targetArea<<endl;
   return DO_CHANGE;
 }
 

--- a/vtkVmtk/DifferentialGeometry/vtkvmtkUnstructuredGridGradientFilter.cxx
+++ b/vtkVmtk/DifferentialGeometry/vtkvmtkUnstructuredGridGradientFilter.cxx
@@ -168,7 +168,7 @@ int vtkvmtkUnstructuredGridGradientFilter::RequestData(
         assembler->SetDirection(j);
         std::cout<<"Assembling system"<<endl;
         assembler->Build();
-       std:: cout<<"Done"<<endl;
+       std::cout<<"Done"<<endl;
           
         vtkvmtkLinearSystem* linearSystem = vtkvmtkLinearSystem::New();
         linearSystem->SetA(sparseMatrix);

--- a/vtkVmtk/DifferentialGeometry/vtkvmtkUnstructuredGridGradientFilter.cxx
+++ b/vtkVmtk/DifferentialGeometry/vtkvmtkUnstructuredGridGradientFilter.cxx
@@ -33,6 +33,7 @@
 #include "vtkInformationVector.h"
 #include "vtkObjectFactory.h"
 
+#include <iostream>
 
 vtkStandardNewMacro(vtkvmtkUnstructuredGridGradientFilter);
 
@@ -123,9 +124,9 @@ int vtkvmtkUnstructuredGridGradientFilter::RequestData(
       assembler->SetSolutionVector(solutionVector);
       assembler->SetQuadratureOrder(this->QuadratureOrder);
       assembler->SetAssemblyModeToGradient();
-      cout<<"Assembling system"<<endl;
+      std::cout<<"Assembling system"<<endl;
       assembler->Build();
-      cout<<"Done"<<endl;
+      std::cout<<"Done"<<endl;
         
       vtkvmtkLinearSystem* linearSystem = vtkvmtkLinearSystem::New();
       linearSystem->SetA(sparseMatrix);
@@ -138,9 +139,9 @@ int vtkvmtkUnstructuredGridGradientFilter::RequestData(
       solver->SetMaximumNumberOfIterations(numberOfInputPoints);
       solver->SetSolverTypeToCG();
       solver->SetPreconditionerTypeToJacobi();
-      cout<<"Solving system"<<endl;
+      std::cout<<"Solving system"<<endl;
       solver->Solve();
-      cout<<"Done"<<endl;
+      std::cout<<"Done"<<endl;
 
       solutionVector->CopyVariableIntoArrayComponent(gradientArray,0,3*i+0);
       solutionVector->CopyVariableIntoArrayComponent(gradientArray,1,3*i+1);
@@ -165,9 +166,9 @@ int vtkvmtkUnstructuredGridGradientFilter::RequestData(
         assembler->SetQuadratureOrder(this->QuadratureOrder);
         assembler->SetAssemblyModeToPartialDerivative();
         assembler->SetDirection(j);
-        cout<<"Assembling system"<<endl;
+        std::cout<<"Assembling system"<<endl;
         assembler->Build();
-        cout<<"Done"<<endl;
+       std:: cout<<"Done"<<endl;
           
         vtkvmtkLinearSystem* linearSystem = vtkvmtkLinearSystem::New();
         linearSystem->SetA(sparseMatrix);
@@ -180,9 +181,9 @@ int vtkvmtkUnstructuredGridGradientFilter::RequestData(
         solver->SetMaximumNumberOfIterations(numberOfInputPoints);
         solver->SetSolverTypeToCG();
         solver->SetPreconditionerTypeToJacobi();
-        cout<<"Solving system"<<endl;
+        std::cout<<"Solving system"<<endl;
         solver->Solve();
-        cout<<"Done"<<endl;
+        std::cout<<"Done"<<endl;
       
         solutionVector->CopyIntoArrayComponent(gradientArray,3*i+j);
        

--- a/vtkVmtk/IO/vtkvmtkFDNEUTReader.cxx
+++ b/vtkVmtk/IO/vtkvmtkFDNEUTReader.cxx
@@ -33,6 +33,7 @@ Version:   $Revision: 1.8 $
 #include "vtkStreamingDemandDrivenPipeline.h"
 #include "vtkvmtkConstants.h"
 
+#include <iostream>
 
 vtkStandardNewMacro(vtkvmtkFDNEUTReader);
 
@@ -457,7 +458,7 @@ int vtkvmtkFDNEUTReader::ReadMeshSimple(const std::string& fname,
         }
       else
         {
-        cout<<"foo"<<endl;
+        std::cout<<"foo"<<endl;
         }
       }
 #if 0

--- a/vtkVmtk/IO/vtkvmtkXdaWriter.cxx
+++ b/vtkVmtk/IO/vtkvmtkXdaWriter.cxx
@@ -30,6 +30,7 @@ Version:   $Revision: 1.6 $
 #include "vtkObjectFactory.h"
 #include "vtkvmtkConstants.h"
 
+#include <iostream>
 
 vtkStandardNewMacro(vtkvmtkXdaWriter);
 
@@ -487,7 +488,7 @@ void vtkvmtkXdaWriter::GetLibmeshConnectivity(int cellType, vtkIdList* libmeshCo
       libmeshConnectivity->SetId(17,15);
       break;
     default:
-      cerr<<"Element type not currently supported in libmesh. Skipping element."<<endl;
+      std::cerr<<"Element type not currently supported in libmesh. Skipping element."<<endl;
       break;
     }
 }
@@ -556,7 +557,7 @@ void vtkvmtkXdaWriter::GetLibmeshFaceOrder(int cellType, vtkIdList* libmeshFaceO
       libmeshFaceOrder->SetId(4,1);
       break;
     default:
-      cerr<<"Element type not currently supported in libmesh. Skipping element."<<endl;
+      std::cerr<<"Element type not currently supported in libmesh. Skipping element."<<endl;
       break;
     }
 }

--- a/vtkVmtk/Misc/vtkvmtkBoundaryLayerGenerator.cxx
+++ b/vtkVmtk/Misc/vtkvmtkBoundaryLayerGenerator.cxx
@@ -36,6 +36,7 @@ Version:   $Revision: 1.7 $
 #include "vtkInformationVector.h"
 #include "vtkObjectFactory.h"
 
+#include <iostream>
 
 vtkStandardNewMacro(vtkvmtkBoundaryLayerGenerator);
 

--- a/vtkVmtk/Misc/vtkvmtkTetGenWrapper.cxx
+++ b/vtkVmtk/Misc/vtkvmtkTetGenWrapper.cxx
@@ -33,6 +33,7 @@ Version:   $Revision: 1.8 $
 #include "vtkObjectFactory.h"
 #include "tetgen.h"
 
+#include <iostream>
 
 vtkStandardNewMacro(vtkvmtkTetGenWrapper);
 
@@ -423,7 +424,7 @@ int vtkvmtkTetGenWrapper::RequestData(
 
   char tetgenOptions[512];
   strcpy(tetgenOptions,tetgenOptionString.c_str());
-  cout<<"TetGen command line options: "<<tetgenOptions<<endl;
+  std::cout<<"TetGen command line options: "<<tetgenOptions<<endl;
   try
     {
     tetrahedralize(tetgenOptions,&in_tetgenio,&out_tetgenio);


### PR DESCRIPTION
Adapted to build against `VTK 9.6`. `cout` and `cerr` generate build time errors.