### PR TITLE
fix: avoid unsafe GetPoint aliasing in steepest-descent interpolation

### DIFF
--- a/vtkVmtk/ComputationalGeometry/vtkvmtkSteepestDescentLineTracer.cxx
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkSteepestDescentLineTracer.cxx
@@ -245,10 +245,18 @@ void vtkvmtkSteepestDescentLineTracer::Backtrace(vtkPolyData* input, vtkIdType s
     previousPoint[0] = currentPoint[0];
     previousPoint[1] = currentPoint[1]; 
     previousPoint[2] = currentPoint[2];
-                
-    currentPoint[0] = input->GetPoint(currentEdge[0])[0] * (1.0 - currentS) + input->GetPoint(currentEdge[1])[0] * currentS;
-    currentPoint[1] = input->GetPoint(currentEdge[0])[1] * (1.0 - currentS) + input->GetPoint(currentEdge[1])[1] * currentS;
-    currentPoint[2] = input->GetPoint(currentEdge[0])[2] * (1.0 - currentS) + input->GetPoint(currentEdge[1])[2] * currentS;
+
+    // Do not call GetPoint(id) twice in one expression: with float points VTK
+    // returns a shared temporary buffer, so the second call overwrites the first
+    // (VTK 9). Copy into locals first (same pattern as GetSteepestDescentInCell).
+    {
+    double edgePoint0[3], edgePoint1[3];
+    input->GetPoint(currentEdge[0], edgePoint0);
+    input->GetPoint(currentEdge[1], edgePoint1);
+    currentPoint[0] = edgePoint0[0] * (1.0 - currentS) + edgePoint1[0] * currentS;
+    currentPoint[1] = edgePoint0[1] * (1.0 - currentS) + edgePoint1[1] * currentS;
+    currentPoint[2] = edgePoint0[2] * (1.0 - currentS) + edgePoint1[2] * currentS;
+    }
                 
     currentScalar = this->DescentArray->GetTuple1(currentEdge[0]) * (1.0 - currentS) + this->DescentArray->GetTuple1(currentEdge[1]) * currentS;
     currentRadius = this->LineDataArray->GetTuple1(currentEdge[0]) * (1.0 - currentS) + this->LineDataArray->GetTuple1(currentEdge[1]) * currentS;

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkSteepestDescentShooter.cxx
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkSteepestDescentShooter.cxx
@@ -173,10 +173,16 @@ void vtkvmtkSteepestDescentShooter::Backtrace(vtkPolyData* input, vtkIdType seed
     previousPoint[0] = currentPoint[0];
     previousPoint[1] = currentPoint[1]; 
     previousPoint[2] = currentPoint[2];
-                
-    currentPoint[0] = input->GetPoint(currentEdge[0])[0] * (1.0 - currentS) + input->GetPoint(currentEdge[1])[0] * currentS;
-    currentPoint[1] = input->GetPoint(currentEdge[0])[1] * (1.0 - currentS) + input->GetPoint(currentEdge[1])[1] * currentS;
-    currentPoint[2] = input->GetPoint(currentEdge[0])[2] * (1.0 - currentS) + input->GetPoint(currentEdge[1])[2] * currentS;
+
+    // Safe GetPoint: avoid shared-temp aliasing when float points (VTK 9).
+    {
+    double edgePoint0[3], edgePoint1[3];
+    input->GetPoint(currentEdge[0], edgePoint0);
+    input->GetPoint(currentEdge[1], edgePoint1);
+    currentPoint[0] = edgePoint0[0] * (1.0 - currentS) + edgePoint1[0] * currentS;
+    currentPoint[1] = edgePoint0[1] * (1.0 - currentS) + edgePoint1[1] * currentS;
+    currentPoint[2] = edgePoint0[2] * (1.0 - currentS) + edgePoint1[2] * currentS;
+    }
                 
     currentScalar = this->DescentArray->GetTuple1(currentEdge[0]) * (1.0 - currentS) + this->DescentArray->GetTuple1(currentEdge[1]) * currentS;
     }


### PR DESCRIPTION
## Summary
Fixes unsafe use of `double* GetPoint(vtkIdType)` twice in one interpolation expression in:
- `vtkvmtkSteepestDescentLineTracer`
- `vtkvmtkSteepestDescentShooter`

Under VTK 9 with float point storage, the returned pointer refers to a shared temporary buffer, so the lerp can collapse to the second endpoint.

## Test plan
- [x] Same mesh + same seeds on VTK 9.1 / MSVC
- [x] Before: jagged centerline (mean turn ~21°, max ~178°)
- [x] After: matches expected smooth path (mean turn ~5°, max ~40°)

Related issue: #486 