### PR TITLE
Find ITK and VTK in VMTKConfig.cmake

### DIFF
--- a/CMake/VMTKConfig.cmake.in
+++ b/CMake/VMTKConfig.cmake.in
@@ -1,3 +1,17 @@
+# Find the ITK and VTK builds used by VMTK. The embedded paths point at the
+# build trees used when VMTK was built (e.g. the superbuild's ITK-Build and
+# VTK-Build directories), so this config is not relocatable. A consumer can
+# override them by setting ITK_DIR/VTK_DIR before find_package(VMTK).
+include(CMakeFindDependencyMacro)
+if(NOT ITK_DIR)
+  set(ITK_DIR "@ITK_DIR@")
+endif()
+if(NOT VTK_DIR)
+  set(VTK_DIR "@VTK_DIR@")
+endif()
+find_dependency(ITK)
+find_dependency(VTK)
+
 # Tell the user project where to find headers and libraries
 set(VMTK_CPP_SOURCE_DIRS "@VMTK_SOURCE_DIR@/vtkVmtk")
 


### PR DESCRIPTION
find_package(VMTK) failed in consumer projects because the exported VMTK-Targets.cmake references ITK and VTK imported targets (such as VTK::CommonCore) that were never defined: the generated VMTKConfig.cmake did not find ITK and VTK, and the superbuild's ITK_DIR/VTK_DIR were not recorded anywhere. Consumers had to manually call find_package(ITK) and find_package(VTK) pointing at the superbuild's internal ITK-Build and VTK-Build directories, which was undocumented.

VMTKConfig.cmake now calls find_dependency(ITK) and find_dependency(VTK) before importing the VMTK targets, defaulting ITK_DIR and VTK_DIR to the build trees used when VMTK was built. Consumers can still override both by setting them before find_package(VMTK).

Reported at
https://discourse.slicer.org/t/problem-with-using-cmakelists-to-run-vmtk-c-code/27936

fixes #448