### PR TITLE
Fix vmtkmeshaddexternallayer and related contrib code

### DIFF
--- a/.github/workflows/build-test-vmtk.yml
+++ b/.github/workflows/build-test-vmtk.yml
@@ -184,7 +184,8 @@ jobs:
             -DVTK_VMTK_WRAP_PYTHON=ON \
             -DBUILD_SHARED_LIBS=ON \
             -DVMTK_USE_RENDERING=ON \
-            -DVMTK_CONTRIB_SCRIPTS=ON
+            -DVMTK_CONTRIB_SCRIPTS=ON \
+            -DVTK_VMTK_CONTRIB=ON
 
       - name: Build and install VMTK
         shell: bash

--- a/distribution/pypi/test_wheel.py
+++ b/distribution/pypi/test_wheel.py
@@ -8,7 +8,11 @@ command for every built wheel). It verifies that:
     linkage against the VTK libraries of the "vtk" wheel),
   * the ITK-based segmentation classes work (which exercises the ITK
     libraries, statically linked on Windows and bundled on Linux/macOS),
-  * the pype mechanism and the vmtk script modules import.
+  * the pype mechanism and the vmtk script modules import,
+  * the contrib scripts and the wrapped vtkVmtk/Contrib classes they
+    need are both present (they are enabled separately at build time,
+    and shipping one without the other broke conda-forge packages,
+    see https://github.com/vmtk/vmtk/issues/443).
 
 No rendering window is created, so the test also runs on headless CI
 machines.
@@ -94,10 +98,36 @@ def test_pypes():
           f"UseJoblib: {bool(script.UseJoblib)})")
 
 
+def test_contrib():
+    from vmtk import vtkvmtk
+    from vmtk import vmtkcontribscripts
+
+    for class_name in [
+        "vtkvmtkBoundaryLayerGenerator2",
+        "vtkvmtkPolyDataSampleFunction",
+    ]:
+        cls = getattr(vtkvmtk, class_name, None)
+        assert cls is not None, (
+            "%s missing: vtkVmtk/Contrib classes were not built "
+            "(VTK_VMTK_CONTRIB)" % class_name
+        )
+        instance = cls()
+        print("instantiated", instance.GetClassName())
+
+    for script_name in [
+        "vmtkBoundaryLayer2",
+        "vmtkMeshAddExternalLayer",
+    ]:
+        script = getattr(vmtkcontribscripts, script_name)()
+        print("instantiated contrib script", script.GetClassName()
+              if hasattr(script, "GetClassName") else type(script).__name__)
+
+
 def main():
     test_import()
     test_itk_filter()
     test_pypes()
+    test_contrib()
     print("vmtk wheel smoke test passed")
     return 0
 

--- a/tests/test_vmtkScripts/CMakeLists.txt
+++ b/tests/test_vmtkScripts/CMakeLists.txt
@@ -40,6 +40,7 @@ set(TEST_VMTKSCRIPTS_SRCS
     test_vmtkimagevolumeviewer.py
     test_vmtklevelsetsegmentation.py
     test_vmtkmarchingcubes.py
+    test_vmtkmeshaddexternallayer.py
     # test_vmtkmeshtonumpy.py
     test_vmtkstatictemporalstreamtracer.py
     test_vmtksurfaceappend.py

--- a/tests/test_vmtkScripts/conftest.py
+++ b/tests/test_vmtkScripts/conftest.py
@@ -359,57 +359,47 @@ def aorta_mesh(input_datadir):
 
 
 @pytest.fixture(scope='module')
-def write_mesh():
+def mesh_reference_datadir():
+    datadir = os.path.join(
+                os.path.dirname(
+                    os.path.dirname(
+                        os.path.realpath(__file__))), 'vmtk-test-data', 'meshreference')
+    if os.path.isdir(datadir):
+        return datadir
+    datadir = '@ExternalData_BINARY_ROOT@/tests/data/meshreference'
+    if os.path.isdir(datadir):
+        return datadir
+    datadir = '@ExternalData_BINARY_ROOT@'.replace('/work/build/ExternalData', '/test_tmp/build/ExternalData/tests/data/meshreference')
+    if os.path.isdir(datadir):
+        return datadir
+    datadir = os.path.join(
+        os.path.dirname(
+            os.path.dirname(
+                os.path.dirname(
+                    os.path.dirname(
+                        os.path.realpath(__file__))))),
+        'vmtk-test-data/meshreference')
+    if not os.path.isdir(datadir):
+        raise ValueError('the vmtk-test-data repository cannot be found at the same level as vmtk. expected it to be at', datadir)
+    return datadir
+
+
+@pytest.fixture(scope='module')
+def write_mesh(mesh_reference_datadir):
     def make_write_mesh(mesh, filename):
         writer = meshwriter.vmtkMeshWriter()
         writer.Mesh = mesh
-        try:
-            datadir = '@ExternalData_BINARY_ROOT@/tests/data/meshreference'
-            if not os.path.isdir(datadir): raise ValueError()
-        except ValueError:
-            try:
-                datadir = '@ExternalData_BINARY_ROOT@'
-                datadir = datadir.replace('/work/build/ExternalData', '/test_tmp/build/ExternalData/tests/data/meshreference')
-                if not os.path.isdir(datadir): raise ValueError()
-            except ValueError:
-                datadir = os.path.join(
-                    os.path.dirname(
-                        os.path.dirname(
-                            os.path.dirname(
-                                os.path.dirname(
-                                    os.path.realpath(__file__))))),
-                    'vmtk-test-data/meshreference')
-                if not os.path.isdir(datadir):
-                    raise ValueError('the vmtk-test-data repository cannot be found at the same level as vmtk. expected it to be at', datadir)
-        writer.OutputFileName = os.path.join(datadir, filename)
+        writer.OutputFileName = os.path.join(mesh_reference_datadir, filename)
         writer.Execute()
         return
     return make_write_mesh
 
 
 @pytest.fixture(scope='module')
-def compare_meshes():
+def compare_meshes(mesh_reference_datadir):
     def make_compare_meshes(mesh, reference_file, tolerance=0.001, method='cellarray', arrayname=''):
         reader = meshreader.vmtkMeshReader()
-        try:
-            datadir = '@ExternalData_BINARY_ROOT@/tests/data/meshreference'
-            if not os.path.isdir(datadir): raise ValueError()
-        except ValueError:
-            try:
-                datadir = '@ExternalData_BINARY_ROOT@'
-                datadir = datadir.replace('/work/build/ExternalData', '/test_tmp/build/ExternalData/tests/data/meshreference')
-                if not os.path.isdir(datadir): raise ValueError()
-            except ValueError:
-                datadir = os.path.join(
-                    os.path.dirname(
-                        os.path.dirname(
-                            os.path.dirname(
-                                os.path.dirname(
-                                    os.path.realpath(__file__))))),
-                    'vmtk-test-data/meshreference')
-                if not os.path.isdir(datadir):
-                    raise ValueError('the vmtk-test-data repository cannot be found at the same level as vmtk. expected it to be at', datadir)
-        reader.InputFileName = os.path.join(datadir, reference_file)
+        reader.InputFileName = os.path.join(mesh_reference_datadir, reference_file)
         reader.Execute()
 
         comp = meshcompare.vmtkMeshCompare()

--- a/tests/test_vmtkScripts/test_vmtkmeshaddexternallayer.py
+++ b/tests/test_vmtkScripts/test_vmtkmeshaddexternallayer.py
@@ -1,0 +1,68 @@
+## Program: VMTK
+## Language:  Python
+## Date:      July 18, 2026
+## Version:   1.5
+
+##   Copyright (c) Luca Antiga, David Steinman. All rights reserved.
+##   See LICENSE file for details.
+
+##      This software is distributed WITHOUT ANY WARRANTY; without even
+##      the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+##      PURPOSE.  See the above copyright notices for more information.
+
+import pytest
+import vtk
+import numpy as np
+from vtk.util import numpy_support
+import vmtk.vmtkmeshaddexternallayer as meshaddexternallayer
+
+
+@pytest.fixture()
+def aorta_mesh_copy(aorta_mesh):
+    # vmtkMeshAddExternalLayer offsets the CellEntityIds of its input mesh in
+    # place, so hand each test its own copy to keep the shared module-scope
+    # fixture pristine
+    mesh = vtk.vtkUnstructuredGrid()
+    mesh.DeepCopy(aorta_mesh)
+    return mesh
+
+
+def test_add_external_layer(aorta_mesh_copy, compare_meshes):
+    inputCells = aorta_mesh_copy.GetNumberOfCells()
+
+    adder = meshaddexternallayer.vmtkMeshAddExternalLayer()
+    adder.Mesh = aorta_mesh_copy
+    adder.Execute()
+
+    ids = numpy_support.vtk_to_numpy(adder.Mesh.GetCellData().GetArray('CellEntityIds'))
+    assert adder.Mesh.GetNumberOfCells() > inputCells
+    assert np.issubdtype(ids.dtype, np.integer)
+    # input ids are {0: volume, 1: boundary surface}; the boundary is remapped
+    # to 2 and the external layer adds its volume cells (id 1) and the outer
+    # extruded surface (id 3)
+    assert set(ids.tolist()) == {0, 1, 2, 3}
+    assert set(ids[inputCells:].tolist()) == {1, 3}
+    assert compare_meshes(adder.Mesh, 'aorta-mesh-external-layer.vtu',
+                          method='cellarray', arrayname='CellEntityIds')
+
+
+def test_add_external_layer_open_profiles(aorta_mesh_copy):
+    # relabel the boundary cells above the mid-plane as inlet/outlet caps so
+    # that extruding the remaining wall produces open profiles
+    ids = numpy_support.vtk_to_numpy(aorta_mesh_copy.GetCellData().GetArray('CellEntityIds'))
+    cellCenters = vtk.vtkCellCenters()
+    cellCenters.SetInputData(aorta_mesh_copy)
+    cellCenters.Update()
+    z = numpy_support.vtk_to_numpy(cellCenters.GetOutput().GetPoints().GetData())[:, 2]
+    zMid = 0.5 * (aorta_mesh_copy.GetBounds()[4] + aorta_mesh_copy.GetBounds()[5])
+    ids[(ids == 1) & (z > zMid)] = 2
+    aorta_mesh_copy.GetCellData().GetArray('CellEntityIds').Modified()
+
+    adder = meshaddexternallayer.vmtkMeshAddExternalLayer()
+    adder.Mesh = aorta_mesh_copy
+    adder.Execute()
+
+    outIds = set(numpy_support.vtk_to_numpy(adder.Mesh.GetCellData().GetArray('CellEntityIds')).tolist())
+    # original ids: volume 0->0, wall 1->2, caps 2->4; external layer: volume
+    # cells 1, outer extruded surface 3, extruded open profiles from 5 upwards
+    assert {0, 1, 2, 3, 4, 5}.issubset(outIds)

--- a/vmtkScripts/contrib/vmtkmeshaddexternallayer.py
+++ b/vmtkScripts/contrib/vmtkmeshaddexternallayer.py
@@ -207,7 +207,7 @@ class vmtkMeshAddExternalLayer(pypes.pypeScript):
         boundaryLayer.NumberOfSubLayers = self.NumberOfSubLayers
         boundaryLayer.SubLayerRatio = self.SubLayerRatio
         boundaryLayer.Thickness = self.Thickness
-        boundaryLayer.ThicknessRatio = self.Thickness
+        boundaryLayer.ThicknessRatio = self.ThicknessRatio
         boundaryLayer.MaximumThickness = self.MaximumThickness
         boundaryLayer.CellEntityIdsArrayName = self.CellEntityIdsArrayName
         boundaryLayer.IncludeExtrudedOpenProfilesCells = self.IncludeExtrudedOpenProfilesCells

--- a/vmtkScripts/contrib/vmtkmeshaddexternallayer.py
+++ b/vmtkScripts/contrib/vmtkmeshaddexternallayer.py
@@ -22,9 +22,11 @@
 
 from __future__ import absolute_import #NEEDS TO STAY AS TOP LEVEL MODULE FOR Py2-3 COMPATIBILITY
 import vtk
+from vtk.util import numpy_support
 from vmtk import vtkvmtk
 import sys
 from vmtk import vmtkscripts
+from vmtk import vmtkboundarylayer2
 
 from vmtk import pypes
 
@@ -195,7 +197,7 @@ class vmtkMeshAddExternalLayer(pypes.pypeScript):
         if self.IncludeSurfaceCells or self.IncludeExtrudedSurfaceCells:
             wallOffset+=1
 
-        boundaryLayer = vmtkscripts.vmtkBoundaryLayer2()
+        boundaryLayer = vmtkboundarylayer2.vmtkBoundaryLayer2()
         boundaryLayer.Mesh = surfaceToMesh.Mesh
         boundaryLayer.WarpVectorsArrayName = 'Normals'
         boundaryLayer.NegateWarpVectors = False
@@ -220,30 +222,16 @@ class vmtkMeshAddExternalLayer(pypes.pypeScript):
         boundaryLayer.Execute()
 
         if cellEntityIdsArray != None:
-            #offset the previous cellentityids to make room for the new ones
-            arrayCalculator = vtk.vtkArrayCalculator()
-            arrayCalculator.SetInputData(self.Mesh)
-            if vtk.vtkVersion.GetVTKMajorVersion()>=9 or (vtk.vtkVersion.GetVTKMajorVersion()>=8 and vtk.vtkVersion.GetVTKMinorVersion()>=1):
-                arrayCalculator.SetAttributeTypeToCellData()
-            else:
-                arrayCalculator.SetAttributeModeToUseCellData()
-            arrayCalculator.AddScalarVariable("entityid",self.CellEntityIdsArrayName,0)
-            arrayCalculator.SetFunction("if( entityid > " + str(self.InletOutletCellEntityId-1) +", entityid + " + str(wallOffset) + ", entityid)")
-            arrayCalculator.SetResultArrayName('CalculatorResult')
-            arrayCalculator.Update()
-
-            #This need to be copied in order to be of the right type (int)
-            cellEntityIdsArray.DeepCopy(arrayCalculator.GetOutput().GetCellData().GetArray('CalculatorResult'))
-
-            arrayCalculator.SetFunction("if( entityid > " + str(self.SurfaceCellEntityId-1) +", entityid + 1, entityid)")
-            arrayCalculator.Update()
-
-            ##This need to be copied in order to be of the right type (int)
-            cellEntityIdsArray.DeepCopy(arrayCalculator.GetOutput().GetCellData().GetArray('CalculatorResult'))
+            #offset the previous cellentityids to make room for the new ones,
+            #operating on the array in place so that its integer type is preserved
+            cellEntityIds = numpy_support.vtk_to_numpy(cellEntityIdsArray)
+            cellEntityIds[cellEntityIds >= self.InletOutletCellEntityId] += wallOffset
+            cellEntityIds[cellEntityIds >= self.SurfaceCellEntityId] += 1
+            cellEntityIdsArray.Modified()
 
         appendFilter = vtkvmtk.vtkvmtkAppendFilter()
-        appendFilter.AddInput(self.Mesh)
-        appendFilter.AddInput(boundaryLayer.Mesh)
+        appendFilter.AddInputData(self.Mesh)
+        appendFilter.AddInputData(boundaryLayer.Mesh)
         appendFilter.Update()
 
         self.Mesh = appendFilter.GetOutput()

--- a/vmtkScripts/contrib/vmtkmeshaddexternallayer.py
+++ b/vmtkScripts/contrib/vmtkmeshaddexternallayer.py
@@ -103,7 +103,8 @@ class vmtkMeshAddExternalLayer(pypes.pypeScript):
         #cut off the volumetric elements
         wallThreshold = vtk.vtkThreshold()
         wallThreshold.SetInputData(self.Mesh)
-        wallThreshold.ThresholdByUpper(self.SurfaceCellEntityId-0.5)
+        wallThreshold.SetThresholdFunction(vtk.vtkThreshold.THRESHOLD_UPPER)
+        wallThreshold.SetUpperThreshold(self.SurfaceCellEntityId-0.5)
         wallThreshold.SetInputArrayToProcess(0,0,0,1,self.CellEntityIdsArrayName)
         wallThreshold.Update()
 
@@ -137,13 +138,15 @@ class vmtkMeshAddExternalLayer(pypes.pypeScript):
         #cut off the boundaries and other surfaces
         extrudeThresholdLower = vtk.vtkThreshold()
         extrudeThresholdLower.SetInputData(wallWithBoundariesMesh)
-        extrudeThresholdLower.ThresholdByLower(self.ExtrudeCellEntityId+0.5)
+        extrudeThresholdLower.SetThresholdFunction(vtk.vtkThreshold.THRESHOLD_LOWER)
+        extrudeThresholdLower.SetLowerThreshold(self.ExtrudeCellEntityId+0.5)
         extrudeThresholdLower.SetInputArrayToProcess(0,0,0,1,self.CellEntityIdsArrayName)
         extrudeThresholdLower.Update()
 
         extrudeThresholdUpper = vtk.vtkThreshold()
         extrudeThresholdUpper.SetInputConnection(extrudeThresholdLower.GetOutputPort())
-        extrudeThresholdUpper.ThresholdByUpper(self.ExtrudeCellEntityId-0.5)
+        extrudeThresholdUpper.SetThresholdFunction(vtk.vtkThreshold.THRESHOLD_UPPER)
+        extrudeThresholdUpper.SetUpperThreshold(self.ExtrudeCellEntityId-0.5)
         extrudeThresholdUpper.SetInputArrayToProcess(0,0,0,1,self.CellEntityIdsArrayName)
         extrudeThresholdUpper.Update()
 

--- a/vmtkScripts/contrib/vmtkmeshclipcenterlines.py
+++ b/vmtkScripts/contrib/vmtkmeshclipcenterlines.py
@@ -269,7 +269,8 @@ class vmtkMeshClipCenterlines(pypes.pypeScript):
             #Get the original surface cells
             meshThreshold = vtk.vtkThreshold()
             meshThreshold.SetInputData(self.Mesh)
-            meshThreshold.ThresholdByUpper(self.WallCellEntityId+0.5)
+            meshThreshold.SetThresholdFunction(vtk.vtkThreshold.THRESHOLD_UPPER)
+            meshThreshold.SetUpperThreshold(self.WallCellEntityId+0.5)
             meshThreshold.SetInputArrayToProcess(0,0,0,1,self.CellEntityIdsArrayName)
             meshThreshold.Update()
 

--- a/vmtkScripts/contrib/vmtkmeshviewer2.py
+++ b/vmtkScripts/contrib/vmtkmeshviewer2.py
@@ -107,9 +107,11 @@ class vmtkMeshViewer2(pypes.pypeScript):
         thresholder = vtk.vtkThreshold()
         thresholder.SetInputData(self.InitialMesh)
         if (self.ThresholdUpper):
-            thresholder.ThresholdByUpper(self.Threshold)
+            thresholder.SetThresholdFunction(vtk.vtkThreshold.THRESHOLD_UPPER)
+            thresholder.SetUpperThreshold(self.Threshold)
         else:
-            thresholder.ThresholdByLower(self.Threshold)
+            thresholder.SetThresholdFunction(vtk.vtkThreshold.THRESHOLD_LOWER)
+            thresholder.SetLowerThreshold(self.Threshold)
         thresholder.SetInputArrayToProcess(0,0,0,1,self.ArrayName)
         thresholder.Update()
         self.Mesh = thresholder.GetOutput()

--- a/vtkVmtk/Contrib/vtkvmtkBoundaryLayerGenerator2.cxx
+++ b/vtkVmtk/Contrib/vtkvmtkBoundaryLayerGenerator2.cxx
@@ -320,27 +320,27 @@ int vtkvmtkBoundaryLayerGenerator2::RequestData(
           }
         
         //Tetrahedralize the cell
+        //Wedge parametric coords
+        double pCoordsWedge[] = {0.0,0.0,0.0, 1.0,0.0,0.0, 0.0,1.0,0.0,
+                   0.0,0.0,1.0, 1.0,0.0,1.0, 0.0,1.0,1.0};
+        //Hexahedron parametric coords
+        double pCoordsHex[] = {0.0,0.0,0.0, 1.0,0.0,0.0,
+                               1.0,1.0,0.0, 0.0,1.0,0.0,
+                               0.0,0.0,1.0, 1.0,0.0,1.0,
+                               1.0,1.0,1.0, 0.0,1.0,1.0};
         double *pCoords = NULL;
         int prismNEdges = 0;
         int prismType = 0;
-        
+
         if (cellType == VTK_TRIANGLE)
           {
           prismType = VTK_WEDGE;
-          //Wedge parametric coords
-          double pCoordsWedge[] = {0.0,0.0,0.0, 1.0,0.0,0.0, 0.0,1.0,0.0,
-                     0.0,0.0,1.0, 1.0,0.0,1.0, 0.0,1.0,1.0};
           pCoords = pCoordsWedge;
           prismNEdges = 9;
           }
         else if (cellType == VTK_QUAD)
           {
-          prismType = VTK_HEXAHEDRON;;
-          //Hexahedron parametric coords
-          double pCoordsHex[] = {0.0,0.0,0.0, 1.0,0.0,0.0,
-                                 1.0,1.0,0.0, 0.0,1.0,0.0,
-                                 0.0,0.0,1.0, 1.0,0.0,1.0,
-                                 1.0,1.0,1.0, 0.0,1.0,1.0};
+          prismType = VTK_HEXAHEDRON;
           pCoords = pCoordsHex;
           prismNEdges = 12;
           }

--- a/vtkVmtk/Contrib/vtkvmtkBoundaryLayerGenerator2.cxx
+++ b/vtkVmtk/Contrib/vtkvmtkBoundaryLayerGenerator2.cxx
@@ -285,7 +285,6 @@ int vtkvmtkBoundaryLayerGenerator2::RequestData(
 
 
   //Add the volumetric elements and the open profiles extensions if necessary
-  boundaryLayerCellArray->InitTraversal();
   int k;
   for (k=0; k<this->NumberOfSubLayers; k++)
     {
@@ -358,11 +357,9 @@ int vtkvmtkBoundaryLayerGenerator2::RequestData(
         
         this->Triangulator->TemplateTriangulate(prismType, prismNPts, prismNEdges);
         
-        //Go to the end of the list
-        while (boundaryLayerCellArray->GetNextCell(nTetraPts,tetraPts));
-        //Location from which the tetras will be inserted
-        vtkIdType tetraStartLoc = boundaryLayerCellArray->GetTraversalLocation();
-        //Insert the new tetras 
+        //Index of the first tetrahedron that is about to be inserted
+        vtkIdType tetraStartId = boundaryLayerCellArray->GetNumberOfCells();
+        //Insert the new tetras
         vtkIdType numTets = this->Triangulator->AddTetras(0,boundaryLayerCellArray);
         
         for (j=0; j<numTets; j++)
@@ -392,11 +389,9 @@ int vtkvmtkBoundaryLayerGenerator2::RequestData(
               
               vtkIdList *tetraPtsList = vtkIdList::New();
               //Go through the tetrahedra we just added
-              boundaryLayerCellArray->SetTraversalLocation(tetraStartLoc);
-              
               for (int k=0; k<numTets; k++)
                 {
-                boundaryLayerCellArray->GetNextCell(nTetraPts,tetraPts);
+                boundaryLayerCellArray->GetCellAtId(tetraStartId + k, nTetraPts, tetraPts);
                 tetraPtsList->Initialize();
                 for (int l=0; l<nTetraPts; l++) 
                   {

--- a/vtkVmtk/Contrib/vtkvmtkBoundaryLayerGenerator2.cxx
+++ b/vtkVmtk/Contrib/vtkvmtkBoundaryLayerGenerator2.cxx
@@ -351,7 +351,7 @@ int vtkvmtkBoundaryLayerGenerator2::RequestData(
         double *p;
         for (p=pCoords, j=0; j<prismNPts; j++, p+=3)
           {
-          outputPoints->GetPoint(j, prismPt);
+          outputPoints->GetPoint(prismPts[j], prismPt);
           this->Triangulator->InsertPoint(prismPts[j], prismPt, p, 0);
           }
         

--- a/vtkVmtk/Contrib/vtkvmtkCellDimensionFilter.cxx
+++ b/vtkVmtk/Contrib/vtkvmtkCellDimensionFilter.cxx
@@ -60,8 +60,8 @@ int vtkvmtkCellDimensionFilter::FillInputPortInformation(int, vtkInformation *in
 void vtkvmtkCellDimensionFilter::ThresholdByLower(int lower)
 {
 #if VTK_MAJOR_VERSION >= 9
-  Threshold->SetUpperThreshold(lower);
-  Threshold->SetThresholdFunction(vtkThreshold::THRESHOLD_UPPER);
+  Threshold->SetLowerThreshold(lower);
+  Threshold->SetThresholdFunction(vtkThreshold::THRESHOLD_LOWER);
 #else
   Threshold->ThresholdByLower(lower);
 #endif
@@ -70,8 +70,8 @@ void vtkvmtkCellDimensionFilter::ThresholdByLower(int lower)
 void vtkvmtkCellDimensionFilter::ThresholdByUpper(int upper)
 {
 #if VTK_MAJOR_VERSION >= 9
-  Threshold->SetLowerThreshold(upper);
-  Threshold->SetThresholdFunction(vtkThreshold::THRESHOLD_LOWER);
+  Threshold->SetUpperThreshold(upper);
+  Threshold->SetThresholdFunction(vtkThreshold::THRESHOLD_UPPER);
 #else
   Threshold->ThresholdByUpper(upper);
 #endif


### PR DESCRIPTION
Fixes #443. Supersedes #444.

`vmtkmeshaddexternallayer` has been broken for years due to several independent
issues. This PR makes it work end-to-end again while keeping `vmtkBoundaryLayer2`
and all of its entity id options (#444 switched to `vmtkBoundaryLayer`, which
silently ignores six of the parameters the script sets and drops part of the
entity id remapping), and fixes the further breakages found while verifying it —
including a decade-old undefined-behavior bug that meant the boundary layer
generator never produced volume cells on Linux/macOS builds at all.

## Script fixes (`vmtkmeshaddexternallayer`)

- **Import `vmtkBoundaryLayer2` from its actual module.** The script called
  `vmtkscripts.vmtkBoundaryLayer2()`, which never worked: it is a contrib script
  (module `vmtk.vmtkboundarylayer2`, aggregated into `vmtkcontribscripts`).
  Importing the script module directly is also safe against the import order of
  the `vmtkcontribscripts` aggregator.
- **Replace the `vtkArrayCalculator` + `DeepCopy` entity id offsetting with an
  in-place numpy remap.** The calculator result is floating point (hence the
  copy back into the integer array), and on VTK builds where the expression
  parser rejects `if()` the result array is missing entirely, so `DeepCopy(None)`
  failed with the `TypeError: ambiguous call` reported in #443. The remap keeps
  the array integer-typed and preserves the original two-pass semantics.
- **`AddInput` → `AddInputData`** on `vtkvmtkAppendFilter` (VTK 6 pipeline API).
- **`ThresholdByUpper/ByLower` → threshold function API** (removed in VTK 9.3).
- **`ThicknessRatio` typo**: the `-thicknessratio` option was passing
  `Thickness` instead.

## vtkVmtk/Contrib C++ fixes

- **Fix a dangling pointer that broke `vtkvmtkBoundaryLayerGenerator2` on every
  non-MSVC build.** The prism parametric coordinate arrays
  (`pCoordsWedge`/`pCoordsHex`) were declared inside the if-blocks selecting the
  prism type, so `pCoords` pointed at an out-of-scope stack array when the
  points were handed to `vtkOrderedTriangulator` — undefined behavior. MSVC
  happens to leave the stack bytes intact, but with gcc/clang the triangulator
  received garbage coordinates, every prism triangulation failed, and the
  generated layer contained **no volume cells at all** on Linux and macOS
  (caught by the new regression test in this PR's CI). This bug is as old as
  the class.
- **Port `vtkvmtkBoundaryLayerGenerator2` to the VTK 9 cell array API.** The
  legacy `GetTraversalLocation`/`SetTraversalLocation` bookkeeping (offsets into
  the VTK ≤ 8 single-array cell storage) produced `vtkCellArray: Invalid
  location, ignoring` errors and incorrect extruded open profile cells. Replaced
  with `GetNumberOfCells()` + `GetCellAtId()` random access.
- **Fix swapped threshold functions in `vtkvmtkCellDimensionFilter`.** Its VTK 9
  code path mapped `ThresholdByUpper(x)` to *keep ≤ x* and vice versa, which
  made `vmtkmeshclipcenterlines` keep every cell instead of only the volume
  cells. Verified on `aorta-mesh.vtu`: `ThresholdByUpper(3)` now returns exactly
  the 297495 tetrahedra, `ThresholdByLower(2)` exactly the 15066 surface cells.
- **Pass the actual prism corner coordinates to the ordered triangulator**
  (`prismPts[j]` instead of the loop index). No output change — the
  triangulation connectivity is determined by the parametric coordinates and
  only point ids are emitted — but it removes a trap for any future use that
  consults geometry.

## Remaining `ThresholdBy*` callers

`vmtkmeshclipcenterlines` and `vmtkmeshviewer2` are ported to the VTK 9
threshold function API as well. These were the last users of the removed
`vtkThreshold` API in the repository (the image scripts use
`vtkImageThreshold`, which still provides it).

## CI / packaging

- **Build `vtkVmtk/Contrib` in the CI workflow** (`-DVTK_VMTK_CONTRIB=ON`).
  The contrib Python scripts were installed (`VMTK_CONTRIB_SCRIPTS=ON`) without
  the C++ classes they wrap, because `VTK_VMTK_CONTRIB` defaults to OFF in
  non-superbuild configurations — the same mismatch that broke the conda-forge
  packages in #443. The conda-forge feedstock should get the same flag.
- **Wheel smoke test now covers contrib**: `distribution/pypi/test_wheel.py`
  verifies both the wrapped Contrib classes and the contrib scripts import and
  instantiate (the PyPI wheel build already enables both flags in `setup.py`).

## Testing

New regression test `tests/test_vmtkScripts/test_vmtkmeshaddexternallayer.py`:

1. a default run on `aorta-mesh.vtu`, checking the cell entity id remapping and
   comparing against a new reference
   (`meshreference/aorta-mesh-external-layer.vtu`, vmtk-test-data@7f5abc0);
2. a run that relabels the boundary cells above the mid-plane as inlet/outlet
   caps so the extruded wall has open profiles, exercising the ported
   `vtkvmtkBoundaryLayerGenerator2` open-profiles code path.

This test caught the dangling-pointer bug on its first CI run: Linux and macOS
produced no volume cells while Windows passed. Verified on Windows (VTK 9.6,
MSVC) and in an ubuntu:22.04 container (VTK 9.6, gcc 11); after the fix the
Linux output matches the Windows-generated reference exactly, so the reference
comparison is platform-independent.
