### PR TITLE
Move static metadata to pyproject.toml (PEP 621)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,12 @@ __pycache__
 .cache
 .DS_Store
 .vscode
+*.lock
 # Build directories at the repository root (anchored so that files elsewhere
 # whose names start with "build", e.g. .github/workflows/build-*.yml, are
 # not ignored)
 /build*/
-# PyPI packaging (setup.py / scikit-build / cibuildwheel)
+# PyPI packaging (setuptools / scikit-build / cibuildwheel)
 _deps/
 _skbuild/
 dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,53 @@
 [build-system]
 requires = [
-  "setuptools>=42",
+  "setuptools>=77",
   "wheel",
   "scikit-build",
   "cmake>=3.16",
   "ninja",
 ]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "vmtk"
+authors = [
+    {name = "Luca Antiga"},
+    {name = "David Steinman"},
+    {name = "Simone Manini"},
+    {name = "Richard Izzo"},
+]
+description = "vmtk - the Vascular Modeling Toolkit"
+readme = "README.md"
+requires-python = ">=3.12"
+keywords = ["vascular", "modeling", "mesh", "segmentation", "centerline", "vtk", "itk"]
+license = "BSD-3-Clause"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Medical Science Apps.",
+]
+# See setup.py for dynamic metadata
+dynamic = ["dependencies", "version"]
+
+[project.optional-dependencies]
+all = [
+    # imported on demand by the numpy reader/writer scripts
+    "h5py",
+    # parallelizes vmtkcenterlinesnetwork (serial fallback without it)
+    "joblib",
+]
+
+[project.scripts]
+vmtk = "vmtk.pypemain:main"
+
+[project.urls]
+"Home" = "https://vmtk.github.io"
+"Bug Reports" = "https://github.com/vmtk/vmtk/issues"
+"Source" = "https://github.com/vmtk/vmtk"
+"Documentation" = "https://vmtk.github.io/documentation"
+
+[tool.setuptools]
+include-package-data = false
+package-dir = {"vmtk" = "vmtk"}
+packages = ["vmtk"]

--- a/setup.py
+++ b/setup.py
@@ -345,25 +345,10 @@ if native_build_needed():
             f"-DVMTK_WHEEL_ITK_RUNTIME_LIB_DIR:PATH={itk_runtime_lib_dir.as_posix()}"
         )
 
-long_description = (repo_root / "README.md").read_text(encoding="utf-8")
-
+# See pyproject.toml for static metadata
 setup(
     name="vmtk",
     version=vmtk_version(),
-    description="vmtk - the Vascular Modeling Toolkit",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="http://vmtk.github.io",
-    author="Luca Antiga, David Steinman, Simone Manini, Richard Izzo",
-    license="BSD",
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: BSD License",
-        "Programming Language :: Python :: 3",
-        "Topic :: Scientific/Engineering :: Medical Science Apps.",
-    ],
-    keywords="vascular modeling mesh segmentation centerline vtk itk",
     # The whole package content is produced by the CMake build (see the
     # VMTK_WHEEL_BUILD option in the top-level CMakeLists.txt, which makes
     # the install rules place everything into a "vmtk" directory).
@@ -372,29 +357,9 @@ setup(
     # the placeholder vmtk/.keep file in the source tree only exists so that
     # the declared package directory is present (the same pattern is used by
     # VTKU3DExporter).
-    packages=["vmtk"],
-    package_dir={"vmtk": "vmtk"},
-    include_package_data=False,
     cmake_args=cmake_args,
-    python_requires=">=3.12",
     install_requires=[
         f"vtk=={vtk_version()}",
         "numpy",
     ],
-    extras_require={
-        # Optional runtime dependencies: joblib parallelizes
-        # vmtkcenterlinesnetwork (serial fallback without it), h5py is
-        # imported on demand by the numpy reader/writer scripts.
-        "all": ["h5py", "joblib"],
-    },
-    entry_points={
-        "console_scripts": [
-            "vmtk = vmtk.pypemain:main",
-        ],
-    },
-    project_urls={
-        "Bug Reports": "https://github.com/vmtk/vmtk/issues",
-        "Source": "https://github.com/vmtk/vmtk",
-        "Documentation": "http://vmtk.github.io/documentation",
-    },
 )


### PR DESCRIPTION
This PR moves static metadata from setup.py to pyproject.toml as specified by [PEP 621](https://peps.python.org/pep-0621/) and supported by [setuptools >= 61](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html). The aim is to get close to a 1:1 conversion, with a minor change to the licence metadata described next.

The minimum version of setuptools is set to >=77 to support [PEP 639](https://peps.python.org/pep-0639/) to improve licence metadata. This involves specifying a valid SPDX identifier (an expression can also be used, if preferred), and removing the deprecated licence classifier.