### PR TITLE
Pypetests for setting of default parameter values

### DIFF
--- a/tests/test_vmtkScripts/CMakeLists.txt
+++ b/tests/test_vmtkScripts/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TEST_VMTKSCRIPTS_SRCS
     conftest.py
     test_importvmtkscripts.py
     test_importvtkvmtk.py
+    test_pypescripts.py
     test_vmtkbifurcationprofiles.py
     test_vmtkbifurcationreferencesystems.py
     test_vmtkbifurcationsections.py

--- a/tests/test_vmtkScripts/test_pypescripts.py
+++ b/tests/test_vmtkScripts/test_pypescripts.py
@@ -1,0 +1,33 @@
+## Program: VMTK
+## Language:  Python
+## Date:      February 12, 2018
+## Version:   1.4
+
+##   Copyright (c) Richard Izzo, Luca Antiga, All rights reserved.
+##   See LICENSE file for details.
+
+##      This software is distributed WITHOUT ANY WARRANTY; without even
+##      the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+##      PURPOSE.  See the above copyright notices for more information.
+
+## Note: this code was contributed by
+##       Ramtin Gharleghi (Github @ramtingh)
+##       University of New South Wales
+
+import pytest
+import inspect
+from vmtk import vmtkscripts, pypes
+
+scripts = []
+for script in vmtkscripts.__dict__.values():
+    if inspect.isclass(script) and issubclass(script, pypes.pypeScript):
+        scripts.append(script)
+
+@pytest.mark.parametrize("script",scripts)
+def test_vmtkpypescript(script):
+    obj = script()
+    missing = []
+    for member in obj.InputMembers:
+        if not hasattr(obj, member.MemberName):
+            missing.append(member.MemberName)
+    assert not missing

--- a/vmtkScripts/vmtkdistancetocenterlines.py
+++ b/vmtkScripts/vmtkdistancetocenterlines.py
@@ -37,7 +37,7 @@ class vmtkDistanceToCenterlines(pypes.pypeScript):
         self.DistanceToCenterlinesArrayName = 'DistanceToCenterlines'
         self.RadiusArrayName = 'MaximumInscribedSphereRadius'
         self.UseRadiusThreshold = 0
-        self.RadiusThreshold = 0.0
+        self.RadiusThreshold = 1.0
 
 
         self.SetScriptName('vmtkdistancetocenterlines')
@@ -52,8 +52,8 @@ class vmtkDistanceToCenterlines(pypes.pypeScript):
             ['ProjectPointArrays','projectarrays','bool',1],
             ['DistanceToCenterlinesArrayName','distancetocenterlinesarray','str',1],
             ['RadiusArrayName','radiusarray','str',1],
-            ['UseRadiusThreshold','useradiusthreshold','bool',0],
-            ['RadiusThreshold','radiusthreshold','float',1,'(0.0,)','set radius threshold']
+            ['UseRadiusThreshold','useradiusthreshold','bool',0,'','cap the output distance array at RadiusThreshold, useful when the array is fed to vmtksurfaceremeshing/vmtkmeshgenerator as TargetEdgeLengthArrayName, to avoid oversized elements at surface points far from any centerline'],
+            ['RadiusThreshold','radiusthreshold','float',1,'(0.0,)','maximum value of the distance array when UseRadiusThreshold is set']
             ])
         self.SetOutputMembers([
             ['Surface','o','vtkPolyData',1,'','','vmtksurfacewriter']


### PR DESCRIPTION
This PR rebases https://github.com/vmtk/vmtk/pull/428 on latest master version.

The missing `UseRadiusThreshold` and `RadiusThreshold` initializations had been added previously, but the default was set to 0.0, which is not useful, therefore in this PR we use the 1.0 value that was in #428.