### PR TITLE
Fix memory leaks in centerline processing filters

### DIFF
--- a/vtkVmtk/ComputationalGeometry/vtkvmtkCenterlineBranchGeometry.cxx
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkCenterlineBranchGeometry.cxx
@@ -351,6 +351,7 @@ double vtkvmtkCenterlineBranchGeometry::ComputeGroupCurvature(vtkPolyData* input
     double curvature = vtkvmtkCenterlineGeometry::ComputeLineCurvature(linePoints,curvatureArray);
 
     curvatureArray->Delete();
+    linePoints->Delete();
 
     groupCurvature += curvature;
     groupCurvatureWeightSum += 1.0;

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkCenterlineSphereDistance.cxx
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkCenterlineSphereDistance.cxx
@@ -176,6 +176,7 @@ void vtkvmtkCenterlineSphereDistance::FindTouchingSphereCenter(vtkPolyData* cent
     if ((sphereDistance0<=0.0) && (sphereDistance1<=0.0))
       {
       touchingSubId = -1;
+      subIds->Delete();
       return;
       }
 

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkCenterlineSplittingAndGroupingFilter.cxx
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkCenterlineSplittingAndGroupingFilter.cxx
@@ -532,6 +532,8 @@ void vtkvmtkCenterlineSplittingAndGroupingFilter::PointInTubeGroupTracts(vtkPoly
   groupIdsArray->Delete();
   tube->Delete();
   tubeCellIds->Delete();
+  centerlineTube->Delete();
+  centerlineTubeCellIds->Delete();
 }
 
 void vtkvmtkCenterlineSplittingAndGroupingFilter::MakeGroupIdsAdjacent(vtkPolyData* centerlineTracts)
@@ -688,6 +690,7 @@ void vtkvmtkCenterlineSplittingAndGroupingFilter::SplitCenterline(vtkPolyData* i
     splitCenterlineCellArray->Delete();
     splitCenterlineCellPointIds->Delete();
     centerlineIdsArray->Delete();
+    tractIdsArray->Delete();
     blankingArray->Delete();
     return;
     }
@@ -808,6 +811,7 @@ void vtkvmtkCenterlineSplittingAndGroupingFilter::SplitCenterline(vtkPolyData* i
   splitCenterlineCellArray->Delete();
   splitCenterlineCellPointIds->Delete();
   centerlineIdsArray->Delete();
+  tractIdsArray->Delete();
   blankingArray->Delete();
 }
 

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkMergeCenterlines.cxx
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkMergeCenterlines.cxx
@@ -179,7 +179,8 @@ int vtkvmtkMergeCenterlines::RequestData(vtkInformation *vtkNotUsed(request), vt
   vtkPolyData* resampledCenterlines = vtkPolyData::New();
   resampledCenterlines->DeepCopy(resampler->GetOutput());
 
-  resampler->Delete(); 
+  resampler->Delete();
+  cleaner->Delete();
 
   radiusArray = resampledCenterlines->GetPointData()->GetArray(this->RadiusArrayName);
 

--- a/vtkVmtk/Misc/vtkvmtkPolyDataNetworkExtraction.cxx
+++ b/vtkVmtk/Misc/vtkvmtkPolyDataNetworkExtraction.cxx
@@ -1925,6 +1925,7 @@ int vtkvmtkPolyDataNetworkExtraction::RequestData(vtkInformation *vtkNotUsed(req
 
   marksArray->Delete();
   modelBoundary->Delete();
+  model->Delete();
  
   double progress = 1.0; 
   this->InvokeEvent(vtkCommand::ProgressEvent,&progress);


### PR DESCRIPTION
Fix leaks of VTK objects that were allocated with New() but never deleted, detected by vtkDebugLeaks at application exit after running network extraction, centerline branch extraction, merging, and branch geometry computation:

- vtkvmtkPolyDataNetworkExtraction::RequestData: model
- vtkvmtkMergeCenterlines::RequestData: cleaner
- vtkvmtkCenterlineSplittingAndGroupingFilter::PointInTubeGroupTracts: centerlineTube and centerlineTubeCellIds
- vtkvmtkCenterlineSplittingAndGroupingFilter::SplitCenterline: tractIdsArray (missing from both the degenerate-input and the normal cleanup path)
- vtkvmtkCenterlineBranchGeometry::ComputeGroupCurvature: linePoints
- vtkvmtkCenterlineSphereDistance::FindTouchingSphereCenter: subIds (skipped on the early return when the query point is inside both spheres)