### PR TITLE
Improve flow extensions

### DIFF
--- a/tests/test_vmtkScripts/CMakeLists.txt
+++ b/tests/test_vmtkScripts/CMakeLists.txt
@@ -23,6 +23,7 @@ set(TEST_VMTKSCRIPTS_SRCS
     test_vmtkcenterlinesnetwork.py
     test_vmtkcenterlinesmoothing.py
     test_vmtkentityextractor.py
+    test_vmtkflowextensions.py
     test_vmtkentitylist.py
     test_vmtkimagebinarize.py
     test_vmtkimagecast.py

--- a/tests/test_vmtkScripts/test_vmtkflowextensions.py
+++ b/tests/test_vmtkScripts/test_vmtkflowextensions.py
@@ -1,0 +1,131 @@
+## Program: VMTK
+## Language:  Python
+
+##   Copyright (c) Luca Antiga, David Steinman. All rights reserved.
+##   See LICENSE file for details.
+
+##      This software is distributed WITHOUT ANY WARRANTY; without even
+##      the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+##      PURPOSE.  See the above copyright notices for more information.
+
+import math
+import pytest
+import vtk
+
+import vmtk.vmtkflowextensions as flowextensions
+from vmtk import vtkvmtk
+
+
+@pytest.fixture(scope='module')
+def elliptic_tube():
+    '''An open-ended tube with a 2:1 elliptic cross-section, extruded along the z axis.
+
+    Its profiles depart from a circle much more than any of the test surfaces, which makes the
+    difference between a preserved and a circularized cross-section easy to measure.
+    '''
+    semiAxisX, semiAxisY, length = 2.0, 1.0, 6.0
+    numberOfCircumferentialPoints, numberOfAxialPoints = 48, 12
+    points = vtk.vtkPoints()
+    polys = vtk.vtkCellArray()
+    for i in range(numberOfAxialPoints):
+        z = length * i / (numberOfAxialPoints - 1.0)
+        for j in range(numberOfCircumferentialPoints):
+            angle = 2.0 * math.pi * j / numberOfCircumferentialPoints
+            points.InsertNextPoint(semiAxisX * math.cos(angle), semiAxisY * math.sin(angle), z)
+    for i in range(numberOfAxialPoints - 1):
+        for j in range(numberOfCircumferentialPoints):
+            p0 = i * numberOfCircumferentialPoints + j
+            p1 = i * numberOfCircumferentialPoints + (j + 1) % numberOfCircumferentialPoints
+            p2 = (i + 1) * numberOfCircumferentialPoints + j
+            p3 = (i + 1) * numberOfCircumferentialPoints + (j + 1) % numberOfCircumferentialPoints
+            polys.InsertNextCell(3, [p0, p1, p3])
+            polys.InsertNextCell(3, [p0, p3, p2])
+    surface = vtk.vtkPolyData()
+    surface.SetPoints(points)
+    surface.SetPolys(polys)
+    return surface
+
+
+def boundary_profiles(surface):
+    '''(radius ratio, mean radius) of each open boundary, measured about its barycenter.
+
+    The radius ratio is 1 for a circular profile and 2 for a 2:1 elliptic one, so it describes the
+    shape of a profile independently of its size and position. Profiles come in the order used by
+    vtkvmtkPolyDataBoundaryExtractor, which is the order the flow extensions filter works in.
+    '''
+    boundaryExtractor = vtkvmtk.vtkvmtkPolyDataBoundaryExtractor()
+    boundaryExtractor.SetInputData(surface)
+    boundaryExtractor.Update()
+    boundaries = boundaryExtractor.GetOutput()
+
+    profiles = []
+    for i in range(boundaries.GetNumberOfCells()):
+        points = boundaries.GetCell(i).GetPoints()
+        barycenter = [0.0, 0.0, 0.0]
+        vtkvmtk.vtkvmtkBoundaryReferenceSystems.ComputeBoundaryBarycenter(points, barycenter)
+        radii = []
+        for j in range(points.GetNumberOfPoints()):
+            point = points.GetPoint(j)
+            radii.append(math.sqrt(sum((point[k] - barycenter[k]) ** 2 for k in range(3))))
+        profiles.append((max(radii) / min(radii), sum(radii) / len(radii)))
+    return profiles
+
+
+def extend(surface, preserveshape, centerlines=None, **kwargs):
+    extensions = flowextensions.vmtkFlowExtensions()
+    extensions.Surface = surface
+    extensions.PreserveCrossSectionShape = preserveshape
+    extensions.Interactive = 0
+    if centerlines is not None:
+        extensions.Centerlines = centerlines
+        extensions.ExtensionMode = 'centerlinedirection'
+    else:
+        extensions.ExtensionMode = 'boundarynormal'
+    for name, value in kwargs.items():
+        setattr(extensions, name, value)
+    extensions.Execute()
+    return extensions.Surface
+
+
+def test_extensions_are_appended_to_the_surface(elliptic_tube):
+    surface = extend(elliptic_tube, 0)
+
+    assert surface.GetNumberOfPoints() > elliptic_tube.GetNumberOfPoints()
+    assert surface.GetNumberOfCells() > elliptic_tube.GetNumberOfCells()
+    # the extensions are left open, one new profile per original open profile
+    assert len(boundary_profiles(surface)) == len(boundary_profiles(elliptic_tube))
+
+
+def test_cross_section_is_circularized_by_default(elliptic_tube):
+    assert all(ratio == pytest.approx(2.0, rel=0.01) for ratio, _ in boundary_profiles(elliptic_tube))
+
+    for ratio, _ in boundary_profiles(extend(elliptic_tube, 0)):
+        assert ratio == pytest.approx(1.0, rel=0.01)
+
+
+def test_cross_section_shape_is_preserved_when_requested(elliptic_tube):
+    for ratio, _ in boundary_profiles(extend(elliptic_tube, 1)):
+        assert ratio == pytest.approx(2.0, rel=0.02)
+
+
+def test_preserved_cross_section_is_scaled_to_the_extension_radius(elliptic_tube):
+    surface = extend(elliptic_tube, 1, AdaptiveExtensionRadius=0, ExtensionRadius=1.0)
+
+    for ratio, meanRadius in boundary_profiles(surface):
+        assert ratio == pytest.approx(2.0, rel=0.02)
+        assert meanRadius == pytest.approx(1.0, rel=0.02)
+
+
+def test_cross_section_shape_is_preserved_along_a_centerline(aorta_surface_openends, aorta_centerline):
+    # the extension direction is the centerline tangent, which is generally not orthogonal to the
+    # boundary, so the extension has to be built from the projected outline
+    inputProfiles = boundary_profiles(aorta_surface_openends)
+    circularized = boundary_profiles(extend(aorta_surface_openends, 0, centerlines=aorta_centerline))
+    preserved = boundary_profiles(extend(aorta_surface_openends, 1, centerlines=aorta_centerline))
+
+    assert len(circularized) == len(inputProfiles)
+    assert len(preserved) == len(inputProfiles)
+    for (inputRatio, _), (circularizedRatio, _), (preservedRatio, _) in zip(inputProfiles, circularized, preserved):
+        assert inputRatio > 1.1
+        assert circularizedRatio == pytest.approx(1.0, rel=0.01)
+        assert preservedRatio == pytest.approx(inputRatio, rel=0.2)

--- a/tests/test_vmtkScripts/test_vmtkflowextensions.py
+++ b/tests/test_vmtkScripts/test_vmtkflowextensions.py
@@ -16,14 +16,9 @@ import vmtk.vmtkflowextensions as flowextensions
 from vmtk import vtkvmtk
 
 
-@pytest.fixture(scope='module')
-def elliptic_tube():
-    '''An open-ended tube with a 2:1 elliptic cross-section, extruded along the z axis.
-
-    Its profiles depart from a circle much more than any of the test surfaces, which makes the
-    difference between a preserved and a circularized cross-section easy to measure.
-    '''
-    semiAxisX, semiAxisY, length = 2.0, 1.0, 6.0
+def elliptic_tube_surface(semiAxisX, semiAxisY):
+    '''An open-ended tube with an elliptic cross-section of the given semi-axes, extruded along z.'''
+    length = 6.0
     numberOfCircumferentialPoints, numberOfAxialPoints = 48, 12
     points = vtk.vtkPoints()
     polys = vtk.vtkCellArray()
@@ -44,6 +39,26 @@ def elliptic_tube():
     surface.SetPoints(points)
     surface.SetPolys(polys)
     return surface
+
+
+@pytest.fixture(scope='module')
+def elliptic_tube():
+    '''An open-ended tube with a 2:1 elliptic cross-section, extruded along the z axis.
+
+    Its profiles depart from a circle much more than any of the test surfaces, which makes the
+    difference between a preserved and a circularized cross-section easy to measure.
+    '''
+    return elliptic_tube_surface(2.0, 1.0)
+
+
+@pytest.fixture(scope='module')
+def flat_tube():
+    '''An open-ended tube with a 6:1 elliptic cross-section, extruded along the z axis.
+
+    Flat enough that most of what makes its profile that shape sits in the high circumferential
+    frequencies, which is where the transition interpolation modes differ.
+    '''
+    return elliptic_tube_surface(6.0, 1.0)
 
 
 def boundary_profiles(surface):
@@ -129,3 +144,81 @@ def test_cross_section_shape_is_preserved_along_a_centerline(aorta_surface_opene
         assert inputRatio > 1.1
         assert circularizedRatio == pytest.approx(1.0, rel=0.01)
         assert preservedRatio == pytest.approx(inputRatio, rel=0.2)
+
+
+def extension_ring_ratios(inputSurface, surface, numberOfRingPoints, numberOfRings):
+    '''Radius ratio of the first rings of the extension grown on the first open boundary.
+
+    The filter copies the input points first and then appends one ring of numberOfRingPoints points
+    per layer, boundary after boundary, so the rings of the first extension follow the input points
+    directly. Reading them one by one shows how the cross-section changes along the transition,
+    which the profile of the finished extension alone does not.
+    '''
+    firstExtensionPointId = inputSurface.GetNumberOfPoints()
+    ratios = []
+    for ring in range(numberOfRings):
+        points = [surface.GetPoint(firstExtensionPointId + ring * numberOfRingPoints + i)
+                  for i in range(numberOfRingPoints)]
+        barycenter = [sum(point[k] for point in points) / len(points) for k in range(3)]
+        radii = [math.sqrt(sum((point[k] - barycenter[k]) ** 2 for k in range(3))) for point in points]
+        ratios.append(max(radii) / min(radii))
+    return ratios
+
+
+# a transition resolved into enough layers for its profile to be read off ring by ring
+TRANSITION = dict(AdaptiveExtensionLength=0, ExtensionLength=6.0, TransitionRatio=0.5)
+
+
+def test_ramp_transition_starts_at_the_real_cross_section(flat_tube):
+    numberOfRingPoints = 200
+    options = dict(TargetNumberOfBoundaryPoints=numberOfRingPoints, **TRANSITION)
+
+    splined = extend(flat_tube, 0, InterpolationMode='thinplatespline', **options)
+    ramped = extend(flat_tube, 0, InterpolationMode='ramp', **options)
+
+    # The boundary is 6:1. The ramp fades the displacement onto it out from full, so the extension
+    # starts on it, while the thin plate spline reproduces it only where it is pinned and loses the
+    # high circumferential frequencies that make a section flat as soon as it moves away.
+    assert extension_ring_ratios(flat_tube, ramped, numberOfRingPoints, 1)[0] > 5.5
+    assert extension_ring_ratios(flat_tube, splined, numberOfRingPoints, 1)[0] < 4.5
+
+
+def test_ramp_transition_spans_the_requested_length(elliptic_tube):
+    numberOfRingPoints = 50
+    options = dict(TargetNumberOfBoundaryPoints=numberOfRingPoints, InterpolationMode='ramp',
+                   AdaptiveExtensionLength=0, ExtensionLength=6.0)
+
+    longTransition = extension_ring_ratios(
+        elliptic_tube, extend(elliptic_tube, 0, TransitionRatio=0.5, **options), numberOfRingPoints, 16)
+    shortTransition = extension_ring_ratios(
+        elliptic_tube, extend(elliptic_tube, 0, TransitionRatio=0.25, **options), numberOfRingPoints, 16)
+
+    # the cross-section goes from the boundary to the circle once, without turning back
+    assert all(longTransition[i] >= longTransition[i+1] for i in range(len(longTransition)-1))
+    # halving the transition halves the number of rings it takes: the short one is already a circle
+    # where the long one is only half way through
+    assert shortTransition[7] == pytest.approx(1.0, rel=0.01)
+    assert longTransition[7] > 1.3
+    assert longTransition[15] == pytest.approx(1.0, rel=0.01)
+
+
+def test_linear_interpolation_mode_blends(elliptic_tube):
+    numberOfRingPoints = 50
+    surface = extend(elliptic_tube, 0, InterpolationMode='linear',
+                     TargetNumberOfBoundaryPoints=numberOfRingPoints, **TRANSITION)
+
+    # the linear mode used to be an empty branch, which left the first ring the plain circle the
+    # extension is swept from, that is a ratio of 1
+    ratios = extension_ring_ratios(elliptic_tube, surface, numberOfRingPoints, 16)
+    assert ratios[0] > 1.8
+    assert ratios[15] == pytest.approx(1.0, rel=0.01)
+
+
+def test_ramp_leaves_a_preserved_cross_section_alone(elliptic_tube):
+    numberOfRingPoints = 50
+    surface = extend(elliptic_tube, 1, InterpolationMode='ramp',
+                     TargetNumberOfBoundaryPoints=numberOfRingPoints, **TRANSITION)
+
+    # nothing to morph: every ring, the transition included, is the 2:1 boundary outline
+    for ratio in extension_ring_ratios(elliptic_tube, surface, numberOfRingPoints, 8):
+        assert ratio == pytest.approx(2.0, rel=0.02)

--- a/vmtkScripts/vmtkflowextensions.py
+++ b/vmtkScripts/vmtkflowextensions.py
@@ -57,8 +57,8 @@ class vmtkFlowExtensions(pypes.pypeScript):
             ['Centerlines','centerlines','vtkPolyData',1,'','','vmtksurfacereader'],
             ['ExtensionMode','extensionmode','str',1,'["centerlinedirection","boundarynormal"]','method for computing the normal for extension'],
             ['PreserveCrossSectionShape','preserveshape','bool',1,'','preserve the shape of the boundary cross-section instead of morphing it to a circle'],
-            ['InterpolationMode','interpolationmode','str',1,'["linear","thinplatespline"]','method for computing interpolation from the model section to the target section'],
-            ['Sigma','sigma','float',1,'(0.0,)','thin plate spline stiffness'],
+            ['InterpolationMode','interpolationmode','str',1,'["linear","thinplatespline","ramp"]','method for computing interpolation from the model section to the target section; thinplatespline is the default, kept for backward compatibility, while ramp gives a smoother transition of the length asked for by transitionratio, which makes a difference on strongly non-circular sections'],
+            ['Sigma','sigma','float',1,'(0.0,)','thin plate spline stiffness; only used by the thinplatespline interpolation mode'],
             ['AdaptiveExtensionLength','adaptivelength','bool',1],
             ['AdaptiveExtensionRadius','adaptiveradius','bool',1],
             ['AdaptiveNumberOfBoundaryPoints','adaptivepoints','bool',1],
@@ -182,6 +182,8 @@ class vmtkFlowExtensions(pypes.pypeScript):
             flowExtensionsFilter.SetInterpolationModeToLinear()
         elif self.InterpolationMode == "thinplatespline":
             flowExtensionsFilter.SetInterpolationModeToThinPlateSpline()
+        elif self.InterpolationMode == "ramp":
+            flowExtensionsFilter.SetInterpolationModeToRamp()
         if self.Interactive:
             flowExtensionsFilter.SetBoundaryIds(boundaryIds)
         flowExtensionsFilter.Update()

--- a/vmtkScripts/vmtkflowextensions.py
+++ b/vmtkScripts/vmtkflowextensions.py
@@ -34,6 +34,7 @@ class vmtkFlowExtensions(pypes.pypeScript):
         self.AdaptiveExtensionLength = 0
         self.AdaptiveExtensionRadius = 1
         self.AdaptiveNumberOfBoundaryPoints = 0
+        self.PreserveCrossSectionShape = 0
         self.ExtensionLength = 1.0
         self.ExtensionRatio = 10.0
         self.ExtensionRadius = 1.0
@@ -55,7 +56,8 @@ class vmtkFlowExtensions(pypes.pypeScript):
             ['Surface','i','vtkPolyData',1,'','','vmtksurfacereader'],
             ['Centerlines','centerlines','vtkPolyData',1,'','','vmtksurfacereader'],
             ['ExtensionMode','extensionmode','str',1,'["centerlinedirection","boundarynormal"]','method for computing the normal for extension'],
-            ['InterpolationMode','interpolationmode','str',1,'["linear","thinplatespline"]','method for computing interpolation from the model section to a circular section'],
+            ['PreserveCrossSectionShape','preserveshape','bool',1,'','preserve the shape of the boundary cross-section instead of morphing it to a circle'],
+            ['InterpolationMode','interpolationmode','str',1,'["linear","thinplatespline"]','method for computing interpolation from the model section to the target section'],
             ['Sigma','sigma','float',1,'(0.0,)','thin plate spline stiffness'],
             ['AdaptiveExtensionLength','adaptivelength','bool',1],
             ['AdaptiveExtensionRadius','adaptiveradius','bool',1],
@@ -165,6 +167,7 @@ class vmtkFlowExtensions(pypes.pypeScript):
         flowExtensionsFilter.SetAdaptiveExtensionLength(self.AdaptiveExtensionLength)
         flowExtensionsFilter.SetAdaptiveExtensionRadius(self.AdaptiveExtensionRadius)
         flowExtensionsFilter.SetAdaptiveNumberOfBoundaryPoints(self.AdaptiveNumberOfBoundaryPoints)
+        flowExtensionsFilter.SetPreserveCrossSectionShape(self.PreserveCrossSectionShape)
         flowExtensionsFilter.SetExtensionLength(self.ExtensionLength)
         flowExtensionsFilter.SetExtensionRatio(self.ExtensionRatio)
         flowExtensionsFilter.SetExtensionRadius(self.ExtensionRadius)

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataFlowExtensionsFilter.cxx
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataFlowExtensionsFilter.cxx
@@ -37,8 +37,66 @@ Version:   $Revision: 1.12 $
 #include "vtkObjectFactory.h"
 #include "vtkVersion.h"
 
+#include <vector>
+
 
 vtkStandardNewMacro(vtkvmtkPolyDataFlowExtensionsFilter);
+
+namespace {
+
+// Resamples a closed polygon into numberOfPoints points equally spaced along its perimeter. The
+// first sample is placed at offsetRatio times the sampling step past the polygon's first point,
+// so that offsetRatio 0.5 gives the set of points staggered halfway between the unshifted ones.
+// The polygon is implicitly closed: the segment from its last to its first point is part of the
+// outline. Returns the perimeter of the polygon.
+double ResampleClosedPolygon(vtkPoints* polygonPoints, int numberOfPoints, double offsetRatio, vtkPoints* resampledPoints)
+{
+  vtkIdType numberOfPolygonPoints = polygonPoints->GetNumberOfPoints();
+
+  std::vector<double> arcLength(numberOfPolygonPoints+1);
+  arcLength[0] = 0.0;
+  double point0[3], point1[3];
+  vtkIdType i;
+  for (i=0; i<numberOfPolygonPoints; i++)
+    {
+    polygonPoints->GetPoint(i,point0);
+    polygonPoints->GetPoint((i+1)%numberOfPolygonPoints,point1);
+    arcLength[i+1] = arcLength[i] + sqrt(vtkMath::Distance2BetweenPoints(point0,point1));
+    }
+  double perimeter = arcLength[numberOfPolygonPoints];
+
+  double step = perimeter / numberOfPoints;
+  vtkIdType segmentId = 0;
+  int j, k;
+  double resampledPoint[3];
+  for (j=0; j<numberOfPoints; j++)
+    {
+    // stations are increasing, so the segment they fall in can be tracked incrementally
+    double station = (j + offsetRatio) * step;
+    while (segmentId < numberOfPolygonPoints-1 && arcLength[segmentId+1] < station)
+      {
+      segmentId++;
+      }
+    double segmentLength = arcLength[segmentId+1] - arcLength[segmentId];
+    double parametricCoordinate = 0.0;
+    if (segmentLength > 0.0)
+      {
+      parametricCoordinate = (station - arcLength[segmentId]) / segmentLength;
+      parametricCoordinate = parametricCoordinate < 0.0 ? 0.0 : (parametricCoordinate > 1.0 ? 1.0 : parametricCoordinate);
+      }
+    polygonPoints->GetPoint(segmentId,point0);
+    polygonPoints->GetPoint((segmentId+1)%numberOfPolygonPoints,point1);
+    for (k=0; k<3; k++)
+      {
+      resampledPoint[k] = point0[k] + parametricCoordinate * (point1[k] - point0[k]);
+      }
+    resampledPoints->InsertNextPoint(resampledPoint);
+    }
+
+  return perimeter;
+}
+
+}
 
 vtkvmtkPolyDataFlowExtensionsFilter::vtkvmtkPolyDataFlowExtensionsFilter()
 {
@@ -50,6 +108,7 @@ vtkvmtkPolyDataFlowExtensionsFilter::vtkvmtkPolyDataFlowExtensionsFilter()
   this->CenterlineNormalEstimationDistanceRatio = 1.0;
   this->AdaptiveExtensionLength = 1;
   this->AdaptiveExtensionRadius = 1;
+  this->PreserveCrossSectionShape = 0;
   this->NumberOfBoundaryPoints = 50;
   this->AdaptiveNumberOfBoundaryPoints = 0;
   this->BoundaryIds = NULL;
@@ -286,32 +345,51 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
       }
 
     double point[3], extensionPoint[3];
+
+    // Project the boundary onto the plane through the barycenter orthogonal to the extension
+    // direction. This is the outline the extension is swept from when PreserveCrossSectionShape
+    // is on, and its mean radius is the extension radius when AdaptiveExtensionRadius is on.
+    vtkPoints* projectedBoundaryPoints = vtkPoints::New();
+    double meanProjectedRadius = 0.0;
+
+    double barycenterToPoint[3];
+    double outOfPlaneDistance;
+    double projectedPoint[3];
+    for (j=0; j<numberOfBoundaryPoints; j++)
+      {
+      boundary->GetPoints()->GetPoint(j,point);
+      for (k=0; k<3; k++)
+        {
+        barycenterToPoint[k] = point[k] - barycenter[k];
+        }
+      outOfPlaneDistance = vtkMath::Dot(barycenterToPoint,flowExtensionNormal);
+      for (k=0; k<3; k++)
+        {
+        barycenterToPoint[k] -= outOfPlaneDistance*flowExtensionNormal[k];
+        projectedPoint[k] = barycenter[k] + barycenterToPoint[k];
+        }
+      projectedBoundaryPoints->InsertNextPoint(projectedPoint);
+      meanProjectedRadius += vtkMath::Norm(barycenterToPoint);
+      }
+    meanProjectedRadius /= numberOfBoundaryPoints;
+
     double targetRadius = 0.0;
 
     if (this->AdaptiveExtensionRadius)
       {
-      double barycenterToPoint[3];
-      double outOfPlaneDistance;
-      double projectedBarycenterToPoint[3];
-      for (j=0; j<numberOfBoundaryPoints; j++)
-        {
-        boundary->GetPoints()->GetPoint(j,point);
-        for (k=0; k<3; k++)
-          {
-          barycenterToPoint[k] = point[k] - barycenter[k];
-          }
-        outOfPlaneDistance = vtkMath::Dot(barycenterToPoint,flowExtensionNormal);
-        for (k=0; k<3; k++)
-          {
-          projectedBarycenterToPoint[k] = barycenterToPoint[k] - outOfPlaneDistance*flowExtensionNormal[k];
-          }
-        targetRadius += vtkMath::Norm(projectedBarycenterToPoint);
-        }
-      targetRadius /= numberOfBoundaryPoints;
+      targetRadius = meanProjectedRadius;
       }
     else
       {
       targetRadius = this->ExtensionRadius;
+      }
+
+    if (this->PreserveCrossSectionShape && meanProjectedRadius < 1E-4 * meanRadius)
+      {
+      vtkWarningMacro(<<"Degenerate boundary outline, skipping flow extension for boundary "<<i);
+      projectedBoundaryPoints->Delete();
+      boundaryIds->Delete();
+      continue;
       }
 
     vtkIdList* newBoundaryIds = vtkIdList::New();
@@ -328,7 +406,7 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
       targetNumberOfBoundaryPoints = numberOfBoundaryPoints;
       }
 
-    double targetDistanceBetweenPoints = 2.0 * sin (vtkMath::Pi() / targetNumberOfBoundaryPoints) * targetRadius;
+    double targetDistanceBetweenPoints = 0.0;
 
     vtkThinPlateSplineTransform* thinPlateSplineTransform = vtkThinPlateSplineTransform::New();
     thinPlateSplineTransform->SetSigma(this->Sigma);
@@ -341,70 +419,123 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
     vtkPoints* targetBoundaryPoints = vtkPoints::New();
     vtkPoints* targetStaggeredBoundaryPoints = vtkPoints::New();
 
-    double baseRadialNormal[3];
-    input->GetPoint(previousBoundaryIds->GetId(0),point);
-    for (k=0; k<3; k++)
-      {
-      baseRadialNormal[k] = point[k] - barycenter[k];
-      }
-    double outOfPlaneComponent = vtkMath::Dot(baseRadialNormal,flowExtensionNormal);
-    for (k=0; k<3; k++)
-      {
-      baseRadialNormal[k] -= outOfPlaneComponent * flowExtensionNormal[k];
-      }
-    vtkMath::Normalize(baseRadialNormal);
     int startNumberOfBoundaryPoints = numberOfBoundaryPoints;
-    double angle = 360.0 / targetNumberOfBoundaryPoints;
-    vtkTransform* transform = vtkTransform::New();
-    transform->RotateWXYZ(0.5*angle,flowExtensionNormal);
-    double testRadialNormal[3];
-    transform->TransformPoint(baseRadialNormal,testRadialNormal);
-    double cross[3], testCross[3], point1[3];
-    vtkMath::Cross(baseRadialNormal,testRadialNormal,testCross);
-    double dist = 0.0;
-    int testId = 1;
-    int numberOfPreviousBoundaryIds = previousBoundaryIds->GetNumberOfIds();
-    while (dist < 1E-8 && testId < numberOfPreviousBoundaryIds)
+
+    if (this->PreserveCrossSectionShape)
       {
-      input->GetPoint(previousBoundaryIds->GetId(testId),point1);
-      dist = sqrt(vtkMath::Distance2BetweenPoints(point,point1));
-      testId++;
+      // The target cross-section is the boundary's own outline, projected onto the plane
+      // orthogonal to the extension direction and uniformly resampled along its perimeter. Since
+      // the samples follow the order of the boundary points, their winding matches the boundary's.
+      double perimeter = ResampleClosedPolygon(projectedBoundaryPoints,targetNumberOfBoundaryPoints,0.0,targetBoundaryPoints);
+      ResampleClosedPolygon(projectedBoundaryPoints,targetNumberOfBoundaryPoints,0.5,targetStaggeredBoundaryPoints);
+
+      double targetPoint[3];
+      double scale = 1.0;
+
+      if (!this->AdaptiveExtensionRadius)
+        {
+        // scale the outline about the barycenter so that its mean radius is the requested
+        // extension radius; the outline is left at its natural size when the radius is adaptive
+        double meanResampledRadius = 0.0;
+        for (j=0; j<targetNumberOfBoundaryPoints; j++)
+          {
+          targetBoundaryPoints->GetPoint(j,targetPoint);
+          for (k=0; k<3; k++)
+            {
+            targetPoint[k] -= barycenter[k];
+            }
+          meanResampledRadius += vtkMath::Norm(targetPoint);
+          }
+        meanResampledRadius /= targetNumberOfBoundaryPoints;
+        scale = targetRadius / meanResampledRadius;
+
+        for (j=0; j<targetNumberOfBoundaryPoints; j++)
+          {
+          targetBoundaryPoints->GetPoint(j,targetPoint);
+          for (k=0; k<3; k++)
+            {
+            targetPoint[k] = barycenter[k] + scale * (targetPoint[k] - barycenter[k]);
+            }
+          targetBoundaryPoints->SetPoint(j,targetPoint);
+          targetStaggeredBoundaryPoints->GetPoint(j,targetPoint);
+          for (k=0; k<3; k++)
+            {
+            targetPoint[k] = barycenter[k] + scale * (targetPoint[k] - barycenter[k]);
+            }
+          targetStaggeredBoundaryPoints->SetPoint(j,targetPoint);
+          }
+        }
+
+      targetDistanceBetweenPoints = scale * perimeter / targetNumberOfBoundaryPoints;
       }
-    double testRadialVector[3];
-    for (k=0; k<3; k++)
+    else
       {
-      testRadialVector[k] = point1[k] - barycenter[k];
-      }
-    vtkMath::Cross(baseRadialNormal,testRadialVector,cross);
-    if (vtkMath::Dot(cross,testCross) < 0.0)
-      {
-      angle *= -1.0;
-      transform->Identity();
-      transform->RotateWXYZ(0.5*angle,flowExtensionNormal); 
-      }
-    double radialVector[3];
-    for (k=0; k<3; k++)
-      {
-      radialVector[k] = targetRadius * baseRadialNormal[k];
-      }
-    double targetPoint[3];
-    for (j=0; j<targetNumberOfBoundaryPoints; j++)
-      {
+      targetDistanceBetweenPoints = 2.0 * sin (vtkMath::Pi() / targetNumberOfBoundaryPoints) * targetRadius;
+
+      double baseRadialNormal[3];
+      input->GetPoint(previousBoundaryIds->GetId(0),point);
       for (k=0; k<3; k++)
         {
-        targetPoint[k] = barycenter[k] + radialVector[k];
+        baseRadialNormal[k] = point[k] - barycenter[k];
         }
-      targetBoundaryPoints->InsertNextPoint(targetPoint);
-      transform->TransformPoint(radialVector,radialVector);
+      double outOfPlaneComponent = vtkMath::Dot(baseRadialNormal,flowExtensionNormal);
       for (k=0; k<3; k++)
         {
-        targetPoint[k] = barycenter[k] + radialVector[k];
+        baseRadialNormal[k] -= outOfPlaneComponent * flowExtensionNormal[k];
         }
-      targetStaggeredBoundaryPoints->InsertNextPoint(targetPoint);
-      transform->TransformPoint(radialVector,radialVector);
+      vtkMath::Normalize(baseRadialNormal);
+      double angle = 360.0 / targetNumberOfBoundaryPoints;
+      vtkTransform* transform = vtkTransform::New();
+      transform->RotateWXYZ(0.5*angle,flowExtensionNormal);
+      double testRadialNormal[3];
+      transform->TransformPoint(baseRadialNormal,testRadialNormal);
+      double cross[3], testCross[3], point1[3];
+      vtkMath::Cross(baseRadialNormal,testRadialNormal,testCross);
+      double dist = 0.0;
+      int testId = 1;
+      int numberOfPreviousBoundaryIds = previousBoundaryIds->GetNumberOfIds();
+      while (dist < 1E-8 && testId < numberOfPreviousBoundaryIds)
+        {
+        input->GetPoint(previousBoundaryIds->GetId(testId),point1);
+        dist = sqrt(vtkMath::Distance2BetweenPoints(point,point1));
+        testId++;
+        }
+      double testRadialVector[3];
+      for (k=0; k<3; k++)
+        {
+        testRadialVector[k] = point1[k] - barycenter[k];
+        }
+      vtkMath::Cross(baseRadialNormal,testRadialVector,cross);
+      if (vtkMath::Dot(cross,testCross) < 0.0)
+        {
+        angle *= -1.0;
+        transform->Identity();
+        transform->RotateWXYZ(0.5*angle,flowExtensionNormal);
+        }
+      double radialVector[3];
+      for (k=0; k<3; k++)
+        {
+        radialVector[k] = targetRadius * baseRadialNormal[k];
+        }
+      double targetPoint[3];
+      for (j=0; j<targetNumberOfBoundaryPoints; j++)
+        {
+        for (k=0; k<3; k++)
+          {
+          targetPoint[k] = barycenter[k] + radialVector[k];
+          }
+        targetBoundaryPoints->InsertNextPoint(targetPoint);
+        transform->TransformPoint(radialVector,radialVector);
+        for (k=0; k<3; k++)
+          {
+          targetPoint[k] = barycenter[k] + radialVector[k];
+          }
+        targetStaggeredBoundaryPoints->InsertNextPoint(targetPoint);
+        transform->TransformPoint(radialVector,radialVector);
+        }
+      transform->Delete();
       }
-    transform->Delete();
-    
+
     if (this->InterpolationMode == USE_THIN_PLATE_SPLINE_INTERPOLATION)
       {
       for (j=0; j<targetNumberOfBoundaryPoints; j++)
@@ -557,6 +688,7 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
       previousBoundaryIds->DeepCopy(newBoundaryIds);
       }
 
+    projectedBoundaryPoints->Delete();
     targetBoundaryPoints->Delete();
     targetStaggeredBoundaryPoints->Delete();
     newBoundaryIds->Delete();

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataFlowExtensionsFilter.cxx
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataFlowExtensionsFilter.cxx
@@ -48,8 +48,10 @@ namespace {
 // first sample is placed at offsetRatio times the sampling step past the polygon's first point,
 // so that offsetRatio 0.5 gives the set of points staggered halfway between the unshifted ones.
 // The polygon is implicitly closed: the segment from its last to its first point is part of the
-// outline. Returns the perimeter of the polygon.
-double ResampleClosedPolygon(vtkPoints* polygonPoints, int numberOfPoints, double offsetRatio, vtkPoints* resampledPoints)
+// outline. If companionPoints is given, it must have as many points as the polygon and is sampled
+// at the same segment and parametric coordinate as the polygon itself, which pairs each sample
+// with its counterpart on the companion polygon. Returns the perimeter of the polygon.
+double ResampleClosedPolygon(vtkPoints* polygonPoints, int numberOfPoints, double offsetRatio, vtkPoints* resampledPoints, vtkPoints* companionPoints = nullptr, vtkPoints* resampledCompanionPoints = nullptr)
 {
   vtkIdType numberOfPolygonPoints = polygonPoints->GetNumberOfPoints();
 
@@ -91,9 +93,105 @@ double ResampleClosedPolygon(vtkPoints* polygonPoints, int numberOfPoints, doubl
       resampledPoint[k] = point0[k] + parametricCoordinate * (point1[k] - point0[k]);
       }
     resampledPoints->InsertNextPoint(resampledPoint);
+
+    if (companionPoints && resampledCompanionPoints)
+      {
+      companionPoints->GetPoint(segmentId,point0);
+      companionPoints->GetPoint((segmentId+1)%numberOfPolygonPoints,point1);
+      for (k=0; k<3; k++)
+        {
+        resampledPoint[k] = point0[k] + parametricCoordinate * (point1[k] - point0[k]);
+        }
+      resampledCompanionPoints->InsertNextPoint(resampledPoint);
+      }
     }
 
   return perimeter;
+}
+
+// Samples a closed polygon along numberOfPoints rays cast from center within the plane orthogonal
+// to planeNormal, the j-th ray pointing at (j + offsetRatio) * angleStep degrees from
+// startDirection, so that the samples pair up with the points of a ring built at the same angular
+// stations. The polygon is sampled where the ray leaves it, that is at the outermost crossing, and
+// the sample is taken on companionPoints, which must have as many points as the polygon, at the
+// same segment and parametric coordinate. Returns false, leaving sampledPoints incomplete, if any
+// ray misses the polygon, which happens when the polygon is not star-shaped about center.
+bool SampleClosedPolygonByAngle(vtkPoints* polygonPoints, vtkPoints* companionPoints, double center[3], double planeNormal[3], double startDirection[3], double angleStep, double offsetRatio, int numberOfPoints, vtkPoints* sampledPoints)
+{
+  vtkIdType numberOfPolygonPoints = polygonPoints->GetNumberOfPoints();
+
+  double firstAxis[3], secondAxis[3];
+  int k;
+  for (k=0; k<3; k++)
+    {
+    firstAxis[k] = startDirection[k];
+    }
+  vtkMath::Cross(planeNormal,firstAxis,secondAxis);
+
+  // in-plane coordinates of the polygon points relative to the center
+  std::vector<double> firstCoordinate(numberOfPolygonPoints), secondCoordinate(numberOfPolygonPoints);
+  double point[3], centerToPoint[3];
+  vtkIdType i;
+  for (i=0; i<numberOfPolygonPoints; i++)
+    {
+    polygonPoints->GetPoint(i,point);
+    for (k=0; k<3; k++)
+      {
+      centerToPoint[k] = point[k] - center[k];
+      }
+    firstCoordinate[i] = vtkMath::Dot(centerToPoint,firstAxis);
+    secondCoordinate[i] = vtkMath::Dot(centerToPoint,secondAxis);
+    }
+
+  double point0[3], point1[3], sampledPoint[3];
+  int j;
+  for (j=0; j<numberOfPoints; j++)
+    {
+    double angle = vtkMath::RadiansFromDegrees((j + offsetRatio) * angleStep);
+    double cosAngle = cos(angle);
+    double sinAngle = sin(angle);
+
+    // the ray is the positive half of the axis the polygon points are projected onto below; a
+    // segment crosses it where its distance to the ray's line changes sign
+    double bestRadius = 0.0;
+    vtkIdType bestSegmentId = -1;
+    double bestParametricCoordinate = 0.0;
+    for (i=0; i<numberOfPolygonPoints; i++)
+      {
+      vtkIdType nextId = (i+1)%numberOfPolygonPoints;
+      double distance0 = -firstCoordinate[i]*sinAngle + secondCoordinate[i]*cosAngle;
+      double distance1 = -firstCoordinate[nextId]*sinAngle + secondCoordinate[nextId]*cosAngle;
+      if (!((distance0 <= 0.0 && distance1 > 0.0) || (distance0 > 0.0 && distance1 <= 0.0)))
+        {
+        continue;
+        }
+      double parametricCoordinate = distance0 / (distance0 - distance1);
+      double radius0 = firstCoordinate[i]*cosAngle + secondCoordinate[i]*sinAngle;
+      double radius1 = firstCoordinate[nextId]*cosAngle + secondCoordinate[nextId]*sinAngle;
+      double radius = radius0 + parametricCoordinate * (radius1 - radius0);
+      if (radius > bestRadius)
+        {
+        bestRadius = radius;
+        bestSegmentId = i;
+        bestParametricCoordinate = parametricCoordinate;
+        }
+      }
+
+    if (bestSegmentId == -1)
+      {
+      return false;
+      }
+
+    companionPoints->GetPoint(bestSegmentId,point0);
+    companionPoints->GetPoint((bestSegmentId+1)%numberOfPolygonPoints,point1);
+    for (k=0; k<3; k++)
+      {
+      sampledPoint[k] = point0[k] + bestParametricCoordinate * (point1[k] - point0[k]);
+      }
+    sampledPoints->InsertNextPoint(sampledPoint);
+    }
+
+  return true;
 }
 
 }
@@ -419,6 +517,13 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
     vtkPoints* targetBoundaryPoints = vtkPoints::New();
     vtkPoints* targetStaggeredBoundaryPoints = vtkPoints::New();
 
+    // The ramp interpolation modes need, for each point of the target cross-section, the point of
+    // the real boundary it grows from. The pairing is built along with the target cross-section
+    // itself, so that it is ordered and one-to-one whatever the shape of the boundary.
+    bool useRampInterpolation = (this->InterpolationMode == USE_LINEAR_INTERPOLATION) || (this->InterpolationMode == USE_RAMP_INTERPOLATION);
+    vtkPoints* rimBoundaryPoints = vtkPoints::New();
+    vtkPoints* rimStaggeredBoundaryPoints = vtkPoints::New();
+
     int startNumberOfBoundaryPoints = numberOfBoundaryPoints;
 
     if (this->PreserveCrossSectionShape)
@@ -426,8 +531,12 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
       // The target cross-section is the boundary's own outline, projected onto the plane
       // orthogonal to the extension direction and uniformly resampled along its perimeter. Since
       // the samples follow the order of the boundary points, their winding matches the boundary's.
-      double perimeter = ResampleClosedPolygon(projectedBoundaryPoints,targetNumberOfBoundaryPoints,0.0,targetBoundaryPoints);
-      ResampleClosedPolygon(projectedBoundaryPoints,targetNumberOfBoundaryPoints,0.5,targetStaggeredBoundaryPoints);
+      // Sampling the boundary itself at the same stations pairs each target point with the point
+      // it is the projection of.
+      vtkPoints* rimPoints = useRampInterpolation ? rimBoundaryPoints : nullptr;
+      vtkPoints* rimStaggeredPoints = useRampInterpolation ? rimStaggeredBoundaryPoints : nullptr;
+      double perimeter = ResampleClosedPolygon(projectedBoundaryPoints,targetNumberOfBoundaryPoints,0.0,targetBoundaryPoints,boundary->GetPoints(),rimPoints);
+      ResampleClosedPolygon(projectedBoundaryPoints,targetNumberOfBoundaryPoints,0.5,targetStaggeredBoundaryPoints,boundary->GetPoints(),rimStaggeredPoints);
 
       double targetPoint[3];
       double scale = 1.0;
@@ -534,6 +643,55 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
         transform->TransformPoint(radialVector,radialVector);
         }
       transform->Delete();
+
+      if (useRampInterpolation)
+        {
+        // Pair each point of the circle with the point of the boundary that lies on the same ray
+        // from the barycenter, so that the transition is a purely radial morph. Matching by
+        // proximity instead would collapse whole arcs of the circle onto the same few boundary
+        // points on a strongly non-circular boundary, and would pair the two facing sides of a
+        // flat one with each other.
+        if (!SampleClosedPolygonByAngle(projectedBoundaryPoints,boundary->GetPoints(),barycenter,flowExtensionNormal,baseRadialNormal,angle,0.0,targetNumberOfBoundaryPoints,rimBoundaryPoints)
+            || !SampleClosedPolygonByAngle(projectedBoundaryPoints,boundary->GetPoints(),barycenter,flowExtensionNormal,baseRadialNormal,angle,0.5,targetNumberOfBoundaryPoints,rimStaggeredBoundaryPoints))
+          {
+          vtkWarningMacro(<<"Boundary "<<i<<" is not star-shaped about its barycenter, pairing it with the extension by arc length instead of by angle");
+          rimBoundaryPoints->Initialize();
+          rimStaggeredBoundaryPoints->Initialize();
+          vtkPoints* discardedPoints = vtkPoints::New();
+          ResampleClosedPolygon(projectedBoundaryPoints,targetNumberOfBoundaryPoints,0.0,discardedPoints,boundary->GetPoints(),rimBoundaryPoints);
+          discardedPoints->Initialize();
+          ResampleClosedPolygon(projectedBoundaryPoints,targetNumberOfBoundaryPoints,0.5,discardedPoints,boundary->GetPoints(),rimStaggeredBoundaryPoints);
+          discardedPoints->Delete();
+          }
+        }
+      }
+
+    // Displacement taking each point of the target cross-section onto the point of the real
+    // boundary it is paired with. Fading it out over the transition length is what the ramp
+    // interpolation modes do, so the extension starts on the real boundary and reaches the target
+    // cross-section exactly at the end of the transition, whatever the shape of the boundary.
+    std::vector<double> displacement, staggeredDisplacement;
+
+    if (useRampInterpolation)
+      {
+      displacement.resize(3*targetNumberOfBoundaryPoints);
+      staggeredDisplacement.resize(3*targetNumberOfBoundaryPoints);
+      double targetPoint[3], rimPoint[3];
+      for (j=0; j<targetNumberOfBoundaryPoints; j++)
+        {
+        targetBoundaryPoints->GetPoint(j,targetPoint);
+        rimBoundaryPoints->GetPoint(j,rimPoint);
+        for (k=0; k<3; k++)
+          {
+          displacement[3*j+k] = rimPoint[k] - targetPoint[k];
+          }
+        targetStaggeredBoundaryPoints->GetPoint(j,targetPoint);
+        rimStaggeredBoundaryPoints->GetPoint(j,rimPoint);
+        for (k=0; k<3; k++)
+          {
+          staggeredDisplacement[3*j+k] = rimPoint[k] - targetPoint[k];
+          }
+        }
       }
 
     if (this->InterpolationMode == USE_THIN_PLATE_SPLINE_INTERPOLATION)
@@ -570,8 +728,9 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
       thinPlateSplineTransform->SetTargetLandmarks(targetLandmarks);
       }
 
+    double transitionLength = extensionLength * this->TransitionRatio;
     int numberOfLayers = extensionLength / targetDistanceBetweenPoints;
-    int numberOfTransitionLayers = (extensionLength * this->TransitionRatio) / targetDistanceBetweenPoints;
+    int numberOfTransitionLayers = transitionLength / targetDistanceBetweenPoints;
     int l;
     for (l=0; l<numberOfLayers; l++)
       {
@@ -592,12 +751,34 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
           }
         if (l<numberOfTransitionLayers)
           {
-          if (this->InterpolationMode == USE_LINEAR_INTERPOLATION)
-            {
-            }
-          else if (this->InterpolationMode == USE_THIN_PLATE_SPLINE_INTERPOLATION)
+          if (this->InterpolationMode == USE_THIN_PLATE_SPLINE_INTERPOLATION)
             {
             thinPlateSplineTransform->TransformPoint(extensionPoint,extensionPoint);
+            }
+          else
+            {
+            // fade the displacement onto the real boundary from full at the boundary to none at
+            // the end of the transition; since the whole displacement is scaled by the same
+            // weight, the transition spans exactly transitionLength however irregular the
+            // boundary is
+            double parametricHeight = (l+1) * targetDistanceBetweenPoints / transitionLength;
+            parametricHeight = parametricHeight > 1.0 ? 1.0 : parametricHeight;
+            double weight = 0.0;
+            if (this->InterpolationMode == USE_LINEAR_INTERPOLATION)
+              {
+              weight = 1.0 - parametricHeight;
+              }
+            else
+              {
+              // smoothstep, flat at both ends, so that the extension leaves the boundary
+              // tangentially and settles into the uniform tube without a crease
+              weight = 1.0 - parametricHeight * parametricHeight * (3.0 - 2.0 * parametricHeight);
+              }
+            const std::vector<double>& layerDisplacement = (l%2 != 0) ? displacement : staggeredDisplacement;
+            for (k=0; k<3; k++)
+              {
+              extensionPoint[k] += weight * layerDisplacement[3*j+k];
+              }
             }
           }
         pointId = outputPoints->InsertNextPoint(extensionPoint);
@@ -691,6 +872,8 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
     projectedBoundaryPoints->Delete();
     targetBoundaryPoints->Delete();
     targetStaggeredBoundaryPoints->Delete();
+    rimBoundaryPoints->Delete();
+    rimStaggeredBoundaryPoints->Delete();
     newBoundaryIds->Delete();
     previousBoundaryIds->Delete();
     boundaryIds->Delete();

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataFlowExtensionsFilter.cxx
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataFlowExtensionsFilter.cxx
@@ -34,6 +34,7 @@ Version:   $Revision: 1.12 $
 #include "vtkCellArray.h"
 #include "vtkInformation.h"
 #include "vtkInformationVector.h"
+#include "vtkNew.h"
 #include "vtkObjectFactory.h"
 #include "vtkVersion.h"
 
@@ -252,22 +253,22 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
       }
     }
 
-  vtkPoints* outputPoints = vtkPoints::New();
-  vtkCellArray* outputPolys = vtkCellArray::New();
+  vtkNew<vtkPoints> outputPoints;
+  vtkNew<vtkCellArray> outputPolys;
 
   outputPoints->DeepCopy(input->GetPoints());
   outputPolys->DeepCopy(input->GetPolys());
 
-  vtkvmtkPolyDataBoundaryExtractor* boundaryExtractor = vtkvmtkPolyDataBoundaryExtractor::New();
+  vtkNew<vtkvmtkPolyDataBoundaryExtractor> boundaryExtractor;
   boundaryExtractor->SetInputData(input);
 
   boundaryExtractor->Update();
 
   vtkPolyData* boundaries = boundaryExtractor->GetOutput();
 
-  vtkPolyData* centerlines = vtkPolyData::New();
-  vtkvmtkPolyBallLine* tube = vtkvmtkPolyBallLine::New();
-  vtkDoubleArray* zeroRadiusArray = vtkDoubleArray::New();
+  vtkNew<vtkPolyData> centerlines;
+  vtkNew<vtkvmtkPolyBallLine> tube;
+  vtkNew<vtkDoubleArray> zeroRadiusArray;
 
   if (this->ExtensionMode == USE_CENTERLINE_DIRECTION)
     {
@@ -309,7 +310,7 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
 
     int numberOfBoundaryPoints = boundary->GetNumberOfPoints();
 
-    vtkIdList* boundaryIds = vtkIdList::New();
+    vtkNew<vtkIdList> boundaryIds;
     int j;
     for (j=0; j<numberOfBoundaryPoints; j++)
       {
@@ -447,7 +448,7 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
     // Project the boundary onto the plane through the barycenter orthogonal to the extension
     // direction. This is the outline the extension is swept from when PreserveCrossSectionShape
     // is on, and its mean radius is the extension radius when AdaptiveExtensionRadius is on.
-    vtkPoints* projectedBoundaryPoints = vtkPoints::New();
+    vtkNew<vtkPoints> projectedBoundaryPoints;
     double meanProjectedRadius = 0.0;
 
     double barycenterToPoint[3];
@@ -485,13 +486,11 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
     if (this->PreserveCrossSectionShape && meanProjectedRadius < 1E-4 * meanRadius)
       {
       vtkWarningMacro(<<"Degenerate boundary outline, skipping flow extension for boundary "<<i);
-      projectedBoundaryPoints->Delete();
-      boundaryIds->Delete();
       continue;
       }
 
-    vtkIdList* newBoundaryIds = vtkIdList::New();
-    vtkIdList* previousBoundaryIds = vtkIdList::New();
+    vtkNew<vtkIdList> newBoundaryIds;
+    vtkNew<vtkIdList> previousBoundaryIds;
     vtkIdType pointId;
 
     previousBoundaryIds->DeepCopy(boundaryIds);
@@ -506,23 +505,23 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
 
     double targetDistanceBetweenPoints = 0.0;
 
-    vtkThinPlateSplineTransform* thinPlateSplineTransform = vtkThinPlateSplineTransform::New();
+    vtkNew<vtkThinPlateSplineTransform> thinPlateSplineTransform;
     thinPlateSplineTransform->SetSigma(this->Sigma);
     thinPlateSplineTransform->SetBasisToR2LogR();
 //    thinPlateSplineTransform->SetBasisToR();
     
-    vtkPoints* sourceLandmarks = vtkPoints::New();
-    vtkPoints* targetLandmarks = vtkPoints::New();
+    vtkNew<vtkPoints> sourceLandmarks;
+    vtkNew<vtkPoints> targetLandmarks;
 
-    vtkPoints* targetBoundaryPoints = vtkPoints::New();
-    vtkPoints* targetStaggeredBoundaryPoints = vtkPoints::New();
+    vtkNew<vtkPoints> targetBoundaryPoints;
+    vtkNew<vtkPoints> targetStaggeredBoundaryPoints;
 
     // The ramp interpolation modes need, for each point of the target cross-section, the point of
     // the real boundary it grows from. The pairing is built along with the target cross-section
     // itself, so that it is ordered and one-to-one whatever the shape of the boundary.
     bool useRampInterpolation = (this->InterpolationMode == USE_LINEAR_INTERPOLATION) || (this->InterpolationMode == USE_RAMP_INTERPOLATION);
-    vtkPoints* rimBoundaryPoints = vtkPoints::New();
-    vtkPoints* rimStaggeredBoundaryPoints = vtkPoints::New();
+    vtkNew<vtkPoints> rimBoundaryPoints;
+    vtkNew<vtkPoints> rimStaggeredBoundaryPoints;
 
     int startNumberOfBoundaryPoints = numberOfBoundaryPoints;
 
@@ -533,8 +532,8 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
       // the samples follow the order of the boundary points, their winding matches the boundary's.
       // Sampling the boundary itself at the same stations pairs each target point with the point
       // it is the projection of.
-      vtkPoints* rimPoints = useRampInterpolation ? rimBoundaryPoints : nullptr;
-      vtkPoints* rimStaggeredPoints = useRampInterpolation ? rimStaggeredBoundaryPoints : nullptr;
+      vtkPoints* rimPoints = useRampInterpolation ? rimBoundaryPoints.GetPointer() : nullptr;
+      vtkPoints* rimStaggeredPoints = useRampInterpolation ? rimStaggeredBoundaryPoints.GetPointer() : nullptr;
       double perimeter = ResampleClosedPolygon(projectedBoundaryPoints,targetNumberOfBoundaryPoints,0.0,targetBoundaryPoints,boundary->GetPoints(),rimPoints);
       ResampleClosedPolygon(projectedBoundaryPoints,targetNumberOfBoundaryPoints,0.5,targetStaggeredBoundaryPoints,boundary->GetPoints(),rimStaggeredPoints);
 
@@ -594,7 +593,7 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
         }
       vtkMath::Normalize(baseRadialNormal);
       double angle = 360.0 / targetNumberOfBoundaryPoints;
-      vtkTransform* transform = vtkTransform::New();
+      vtkNew<vtkTransform> transform;
       transform->RotateWXYZ(0.5*angle,flowExtensionNormal);
       double testRadialNormal[3];
       transform->TransformPoint(baseRadialNormal,testRadialNormal);
@@ -642,7 +641,6 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
         targetStaggeredBoundaryPoints->InsertNextPoint(targetPoint);
         transform->TransformPoint(radialVector,radialVector);
         }
-      transform->Delete();
 
       if (useRampInterpolation)
         {
@@ -657,11 +655,10 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
           vtkWarningMacro(<<"Boundary "<<i<<" is not star-shaped about its barycenter, pairing it with the extension by arc length instead of by angle");
           rimBoundaryPoints->Initialize();
           rimStaggeredBoundaryPoints->Initialize();
-          vtkPoints* discardedPoints = vtkPoints::New();
+          vtkNew<vtkPoints> discardedPoints;
           ResampleClosedPolygon(projectedBoundaryPoints,targetNumberOfBoundaryPoints,0.0,discardedPoints,boundary->GetPoints(),rimBoundaryPoints);
           discardedPoints->Initialize();
           ResampleClosedPolygon(projectedBoundaryPoints,targetNumberOfBoundaryPoints,0.5,discardedPoints,boundary->GetPoints(),rimStaggeredBoundaryPoints);
-          discardedPoints->Delete();
           }
         }
       }
@@ -869,28 +866,10 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
       previousBoundaryIds->DeepCopy(newBoundaryIds);
       }
 
-    projectedBoundaryPoints->Delete();
-    targetBoundaryPoints->Delete();
-    targetStaggeredBoundaryPoints->Delete();
-    rimBoundaryPoints->Delete();
-    rimStaggeredBoundaryPoints->Delete();
-    newBoundaryIds->Delete();
-    previousBoundaryIds->Delete();
-    boundaryIds->Delete();
-    thinPlateSplineTransform->Delete();
-    sourceLandmarks->Delete();
-    targetLandmarks->Delete();
     }
 
   output->SetPoints(outputPoints);
   output->SetPolys(outputPolys);
-
-  outputPoints->Delete();
-  outputPolys->Delete();
-
-  tube->Delete();
-  zeroRadiusArray->Delete();
-  boundaryExtractor->Delete();
 
   return 1;
 }

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataFlowExtensionsFilter.h
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataFlowExtensionsFilter.h
@@ -16,18 +16,23 @@ Program:   VMTK
 =========================================================================*/
 /**
  * @class   vtkvmtkPolyDataFlowExtensionsFilter
- * @brief   Extend open boundaries of a surface with straight (or centerline-following) tubes, tapering the cross-section to a circle.
+ * @brief   Extend open boundaries of a surface with straight (or centerline-following) tubes, tapering the cross-section to a target shape.
  * @ingroup ComputationalGeometry
  *
  * For each selected open boundary of the input surface, this filter appends a tubular extension that
  * grows outward from the boundary along a direction either estimated from the local centerline
  * tangent (ExtensionMode = USE_CENTERLINE_DIRECTION) or from the boundary's own normal (ExtensionMode
- * = USE_NORMAL_TO_BOUNDARY), and morphs the boundary's original (possibly irregular) cross-sectional
- * shape into a circular one over the initial TransitionRatio fraction of the extension, using either
- * linear or thin-plate-spline interpolation (InterpolationMode). This is the filter behind the
- * vmtkflowextensions pype script, which is typically used to add inlet/outlet flow extensions to a
- * vascular surface before CFD meshing, so that boundary conditions can be applied away from
- * geometrically complex regions and inlet/outlet flow profiles have room to develop/relax.
+ * = USE_NORMAL_TO_BOUNDARY). The extension is swept from a target cross-section, which is a circle by
+ * default, or the boundary's own outline when PreserveCrossSectionShape is on. The boundary's original
+ * (possibly irregular and non-planar) shape is morphed into the target cross-section over the initial
+ * TransitionRatio fraction of the extension, using either linear or thin-plate-spline interpolation
+ * (InterpolationMode). This is the filter behind the vmtkflowextensions pype script, which is typically
+ * used to add inlet/outlet flow extensions to a vascular surface before CFD meshing, so that boundary
+ * conditions can be applied away from geometrically complex regions and inlet/outlet flow profiles have
+ * room to develop/relax.
+ *
+ * The extension is left open: its last ring of points is the new inlet/outlet boundary, to be closed
+ * downstream (e.g. by vtkvmtkSimpleCapPolyData or vtkvmtkCapPolyData) if a closed surface is needed.
  *
  * @sa
  * vtkvmtkPolyDataBoundaryExtractor, vtkvmtkBoundaryReferenceSystems, vtkvmtkPolyBallLine
@@ -79,6 +84,8 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataFlowExtensionsFilter
   ///@{
   /**
    * Set/Get the absolute radius of the extension, used when AdaptiveExtensionRadius is off. Default: 1.0.
+   * When PreserveCrossSectionShape is on, the boundary outline is uniformly scaled so that its mean
+   * radius equals this value, rather than being replaced by a circle of this radius.
    */
   vtkSetMacro(ExtensionRadius,double);
   vtkGetMacro(ExtensionRadius,double);
@@ -87,8 +94,10 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataFlowExtensionsFilter
   ///@{
   /**
    * Set/Get the fraction of the extension length, starting from the original boundary, over which the
-   * cross-section is morphed from its original (possibly non-circular) shape into a circle. Beyond this
-   * fraction, the extension is a straight, uniform-radius tube. Default: 0.5.
+   * cross-section is morphed from its original shape into the target cross-section. Beyond this
+   * fraction, the extension is a straight, uniform tube. When PreserveCrossSectionShape is on, the
+   * target cross-section is the boundary's own outline, so the transition only reconciles the extension
+   * with the real, possibly oblique and non-planar rim. Default: 0.5.
    */
   vtkSetMacro(TransitionRatio,double);
   vtkGetMacro(TransitionRatio,double);
@@ -97,8 +106,9 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataFlowExtensionsFilter
   ///@{
   /**
    * Set/Get the stiffness parameter of the thin-plate-spline transform used to morph the boundary's
-   * cross-section into a circle when InterpolationMode is USE_THIN_PLATE_SPLINE_INTERPOLATION. Larger
-   * values produce a stiffer, less locally-deforming transform. Default: 1.0.
+   * cross-section into the target cross-section when InterpolationMode is
+   * USE_THIN_PLATE_SPLINE_INTERPOLATION. Larger values produce a stiffer, less locally-deforming
+   * transform. Default: 1.0.
    */
   vtkSetMacro(Sigma,double);
   vtkGetMacro(Sigma,double);
@@ -136,7 +146,21 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataFlowExtensionsFilter
 
   ///@{
   /**
-   * Set/Get the number of points used to discretize the (circular) cross-section of the extension,
+   * Toggle whether the extension keeps the cross-sectional shape of the boundary it grows from (on),
+   * or morphs it into a circle (off, default). When on, the target cross-section is the boundary
+   * outline projected onto the plane orthogonal to the extension direction, uniformly resampled by
+   * arc length, so that the area distribution of a non-circular inlet/outlet is not altered. Note
+   * that a strongly concave (non star-shaped) preserved outline may be difficult to cap downstream
+   * with barycenter-fan cappers, just like the original boundary it reproduces. Default: off.
+   */
+  vtkSetMacro(PreserveCrossSectionShape,int);
+  vtkGetMacro(PreserveCrossSectionShape,int);
+  vtkBooleanMacro(PreserveCrossSectionShape,int);
+  ///@}
+
+  ///@{
+  /**
+   * Set/Get the number of points used to discretize the target cross-section of the extension,
    * used when AdaptiveNumberOfBoundaryPoints is off. Default: 50.
    */
   vtkSetMacro(NumberOfBoundaryPoints,int);
@@ -145,8 +169,8 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataFlowExtensionsFilter
 
   ///@{
   /**
-   * Toggle whether the number of points used to discretize the extension's cross-section is taken
-   * equal to the number of points on the original boundary (on), or from NumberOfBoundaryPoints (off).
+   * Toggle whether the number of points used to discretize the extension's target cross-section is
+   * taken equal to the number of points on the original boundary (on), or from NumberOfBoundaryPoints (off).
    * Default: off.
    */
   vtkSetMacro(AdaptiveNumberOfBoundaryPoints,int);
@@ -183,7 +207,7 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataFlowExtensionsFilter
   ///@{
   /**
    * Set/Get the method used to morph the extension's cross-section from the original boundary shape
-   * into a circle over the TransitionRatio portion of the extension: USE_LINEAR_INTERPOLATION or
+   * into the target cross-section over the TransitionRatio portion of the extension: USE_LINEAR_INTERPOLATION or
    * USE_THIN_PLATE_SPLINE_INTERPOLATION (default). Use the SetInterpolationModeToLinear() /
    * SetInterpolationModeToThinPlateSpline() convenience methods instead of setting the integer value
    * directly.
@@ -227,6 +251,8 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataFlowExtensionsFilter
 
   int AdaptiveExtensionLength;
   int AdaptiveExtensionRadius;
+
+  int PreserveCrossSectionShape;
 
   int NumberOfBoundaryPoints;
   int AdaptiveNumberOfBoundaryPoints;

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataFlowExtensionsFilter.h
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataFlowExtensionsFilter.h
@@ -25,8 +25,8 @@ Program:   VMTK
  * = USE_NORMAL_TO_BOUNDARY). The extension is swept from a target cross-section, which is a circle by
  * default, or the boundary's own outline when PreserveCrossSectionShape is on. The boundary's original
  * (possibly irregular and non-planar) shape is morphed into the target cross-section over the initial
- * TransitionRatio fraction of the extension, using either linear or thin-plate-spline interpolation
- * (InterpolationMode). This is the filter behind the vmtkflowextensions pype script, which is typically
+ * TransitionRatio fraction of the extension, either by a thin-plate-spline warp or by fading out a
+ * ramp (InterpolationMode). This is the filter behind the vmtkflowextensions pype script, which is typically
  * used to add inlet/outlet flow extensions to a vascular surface before CFD meshing, so that boundary
  * conditions can be applied away from geometrically complex regions and inlet/outlet flow profiles have
  * room to develop/relax.
@@ -108,7 +108,7 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataFlowExtensionsFilter
    * Set/Get the stiffness parameter of the thin-plate-spline transform used to morph the boundary's
    * cross-section into the target cross-section when InterpolationMode is
    * USE_THIN_PLATE_SPLINE_INTERPOLATION. Larger values produce a stiffer, less locally-deforming
-   * transform. Default: 1.0.
+   * transform. Ignored by the ramp interpolation modes. Default: 1.0.
    */
   vtkSetMacro(Sigma,double);
   vtkGetMacro(Sigma,double);
@@ -162,6 +162,17 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataFlowExtensionsFilter
   /**
    * Set/Get the number of points used to discretize the target cross-section of the extension,
    * used when AdaptiveNumberOfBoundaryPoints is off. Default: 50.
+   *
+   * This count also sets how finely the transition is resolved, because the extension is built one
+   * layer of points at a time and the layers are spaced by the distance between two neighbouring
+   * points of the target cross-section: 2 * sin(pi/NumberOfBoundaryPoints) * radius for a circular
+   * target cross-section, perimeter/NumberOfBoundaryPoints for a preserved one. The number of
+   * layers the transition is made of therefore grows in proportion to NumberOfBoundaryPoints, and
+   * the first layer, which is one layer thickness away from the boundary, gets that much closer to
+   * it. Raising this is what makes the junction between the surface and the extension smooth on a
+   * strongly non-circular boundary, where the default 50 leaves the transition a handful of coarse
+   * layers. The cost is quadratic: NumberOfBoundaryPoints points per layer, over a number of layers
+   * proportional to NumberOfBoundaryPoints.
    */
   vtkSetMacro(NumberOfBoundaryPoints,int);
   vtkGetMacro(NumberOfBoundaryPoints,int);
@@ -171,6 +182,9 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataFlowExtensionsFilter
   /**
    * Toggle whether the number of points used to discretize the extension's target cross-section is
    * taken equal to the number of points on the original boundary (on), or from NumberOfBoundaryPoints (off).
+   * Turning this on keeps the extension at the mesh density of the surface it grows from, which on
+   * a finely meshed surface also gives the transition the thin layers it needs to be smooth,
+   * without having to pick a count; see NumberOfBoundaryPoints for why the count matters.
    * Default: off.
    */
   vtkSetMacro(AdaptiveNumberOfBoundaryPoints,int);
@@ -207,10 +221,30 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataFlowExtensionsFilter
   ///@{
   /**
    * Set/Get the method used to morph the extension's cross-section from the original boundary shape
-   * into the target cross-section over the TransitionRatio portion of the extension: USE_LINEAR_INTERPOLATION or
-   * USE_THIN_PLATE_SPLINE_INTERPOLATION (default). Use the SetInterpolationModeToLinear() /
-   * SetInterpolationModeToThinPlateSpline() convenience methods instead of setting the integer value
-   * directly.
+   * into the target cross-section over the TransitionRatio portion of the extension.
+   *
+   * USE_THIN_PLATE_SPLINE_INTERPOLATION warps the transition portion of the extension with a
+   * thin-plate spline pinned to the original boundary at one end and to the undeformed extension at
+   * the other. It is the default, and is kept as such for backward compatibility. A thin-plate
+   * spline reproduces the boundary exactly only where it is pinned, and loses the finer features of
+   * the cross-section faster than the coarse ones as it moves away, so on a strongly non-circular
+   * (say, flat) boundary most of the transition happens within the first layers of the extension
+   * and lengthening TransitionRatio does not spread it out.
+   *
+   * USE_LINEAR_INTERPOLATION and USE_RAMP_INTERPOLATION instead pair each point of the target
+   * cross-section with the point of the boundary it grows from, and fade the displacement between
+   * the two out over the transition: linearly for the former, and with a smoothstep, flat at both
+   * ends, for the latter. Both make the extension start on the real cross-section and reach the
+   * target one exactly at the end of the transition, however non-circular the boundary is, so the
+   * transition is both smoother and as long as TransitionRatio asks for. USE_RAMP_INTERPOLATION is
+   * the one to prefer: being flat at both ends, it leaves no crease where the extension meets the
+   * boundary or where it becomes a uniform tube. How closely the extension actually starts on the
+   * boundary is still limited by the thickness of its first layer, so a strongly non-circular
+   * boundary also wants a NumberOfBoundaryPoints high enough to resolve the transition into thin
+   * layers.
+   *
+   * Use the SetInterpolationModeToLinear() / SetInterpolationModeToThinPlateSpline() /
+   * SetInterpolationModeToRamp() convenience methods instead of setting the integer value directly.
    */
   vtkSetMacro(InterpolationMode,int);
   vtkGetMacro(InterpolationMode,int);
@@ -218,6 +252,8 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataFlowExtensionsFilter
   { this->SetInterpolationMode(USE_LINEAR_INTERPOLATION); }
   void SetInterpolationModeToThinPlateSpline()
   { this->SetInterpolationMode(USE_THIN_PLATE_SPLINE_INTERPOLATION); }
+  void SetInterpolationModeToRamp()
+  { this->SetInterpolationMode(USE_RAMP_INTERPOLATION); }
   ///@}
 
 //BTX
@@ -228,7 +264,8 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataFlowExtensionsFilter
 
   enum {
     USE_LINEAR_INTERPOLATION = 0,
-    USE_THIN_PLATE_SPLINE_INTERPOLATION
+    USE_THIN_PLATE_SPLINE_INTERPOLATION,
+    USE_RAMP_INTERPOLATION
   };
 //ETX
 


### PR DESCRIPTION
Flow extensions were always swept from a circle, which alters the cross-sectional area
distribution at non-circular inlets and outlets. This PR adds two new options to
`vtkvmtkPolyDataFlowExtensionsFilter` that let the extension follow the real cross-section.
Defaults are unchanged and default-mode output is identical to before.

- **`PreserveCrossSectionShape`** (`-preserveshape`, off by default): Do not change cross-section to circular. Kept at natural size when `AdaptiveExtensionRadius` is on, scaled to `ExtensionRadius` when it is off.

- **Ramp interpolation modes** (`-interpolationmode ramp|linear`, `thinplatespline` still the
  default): a thin-plate spline rounds off the first layers of the extension. In contrast, in the new mode each point of the target cross-section is paired with the boundary
  point it grows from and the displacement is faded out over the transition, so the extension
  starts on the real cross-section and reaches the target one exactly at the end of the
  transition. `ramp` fades with a smoothstep, `linear` (until now an empty branch that left a
  hard step) fades linearly. Pairing is by angle for a circular target and by projection for a
  preserved one, falling back to arc length with a warning on boundaries that are not star-shaped
  about their barycenter.

Also fixes a memory leak in `RequestData`: the `centerlines` polydata was never deleted, and the
early return on an invalid `ExtensionMode` leaked everything allocated up to that point.

`test_vmtkflowextensions.py` covers both features on an elliptic tube, a flat tube and an aorta
extended along its centerline: shape preservation along a boundary normal and a centerline,
scaling to `ExtensionRadius`, and the ramp transition starting at the real cross-section and
spanning the requested length.

Original:

<img width="605" height="293" alt="image" src="https://github.com/user-attachments/assets/5885b36e-a91e-42f7-b3b1-31202157d658" />

Ramp mode (smooth transition):

<img width="616" height="257" alt="image" src="https://github.com/user-attachments/assets/567502ed-ecdf-4460-8dee-2e61e7e08bfb" />

Preserve cross-section mode (no transition, cross-section shape is preserved):

<img width="656" height="253" alt="image" src="https://github.com/user-attachments/assets/72550f2b-2a42-471c-9f5e-82a5954fbce0" />
