### PR TITLE
Add per-boundary extension length scale factors to flow extensions

### DIFF
--- a/tests/test_vmtkScripts/test_vmtkflowextensions.py
+++ b/tests/test_vmtkScripts/test_vmtkflowextensions.py
@@ -214,6 +214,36 @@ def test_linear_interpolation_mode_blends(elliptic_tube):
     assert ratios[15] == pytest.approx(1.0, rel=0.01)
 
 
+def extension_growths(inputSurface, surface):
+    '''How far the surface grew past the input at either end of the z axis, in ascending order.
+
+    The tube fixtures are extruded along z and extended along their boundary normals, so each
+    extension's length is the growth of the z extent on its side. Sorting makes the result
+    independent of the order the boundary extractor happens to number the two boundaries in.
+    '''
+    inputBounds = inputSurface.GetBounds()
+    bounds = surface.GetBounds()
+    return sorted([inputBounds[4] - bounds[4], bounds[5] - inputBounds[5]])
+
+
+def test_extension_length_scale_factors_scale_each_extension(elliptic_tube):
+    options = dict(AdaptiveExtensionLength=0, ExtensionLength=2.0)
+
+    unscaled = extension_growths(elliptic_tube, extend(elliptic_tube, 0, **options))
+    scaled = extension_growths(
+        elliptic_tube, extend(elliptic_tube, 0, ExtensionLengthScaleFactors=[2.0, 0.5], **options))
+    partial = extension_growths(
+        elliptic_tube, extend(elliptic_tube, 0, ExtensionLengthScaleFactors=[3.0], **options))
+
+    # extensions are built in whole layers, so lengths match the request only to within a layer
+    assert all(growth == pytest.approx(2.0, rel=0.1) for growth in unscaled)
+    assert scaled[0] == pytest.approx(0.5 * 2.0, rel=0.15)
+    assert scaled[1] == pytest.approx(2.0 * 2.0, rel=0.1)
+    # a boundary beyond the end of the list keeps its unscaled length
+    assert partial[0] == pytest.approx(2.0, rel=0.1)
+    assert partial[1] == pytest.approx(3.0 * 2.0, rel=0.1)
+
+
 def test_ramp_leaves_a_preserved_cross_section_alone(elliptic_tube):
     numberOfRingPoints = 50
     surface = extend(elliptic_tube, 1, InterpolationMode='ramp',

--- a/vmtkScripts/vmtkflowextensions.py
+++ b/vmtkScripts/vmtkflowextensions.py
@@ -37,6 +37,7 @@ class vmtkFlowExtensions(pypes.pypeScript):
         self.PreserveCrossSectionShape = 0
         self.ExtensionLength = 1.0
         self.ExtensionRatio = 10.0
+        self.ExtensionLengthScaleFactors = None
         self.ExtensionRadius = 1.0
         self.TransitionRatio = 0.25
         self.TargetNumberOfBoundaryPoints = 50
@@ -64,6 +65,7 @@ class vmtkFlowExtensions(pypes.pypeScript):
             ['AdaptiveNumberOfBoundaryPoints','adaptivepoints','bool',1],
             ['ExtensionLength','extensionlength','float',1,'(0.0,)'],
             ['ExtensionRatio','extensionratio','float',1,'(0.0,)'],
+            ['ExtensionLengthScaleFactors','extensionlengthscalefactors','float',-1,'(0.0,)','per-boundary scale factors applied to the extension length, indexed by boundary id; boundaries beyond the end of the list are not scaled'],
             ['ExtensionRadius','extensionradius','float',1,'(0.0,)'],
             ['TransitionRatio','transitionratio','float',1,'(0.0,)'],
             ['TargetNumberOfBoundaryPoints','boundarypoints','int',1,'(0,)'],
@@ -170,6 +172,11 @@ class vmtkFlowExtensions(pypes.pypeScript):
         flowExtensionsFilter.SetPreserveCrossSectionShape(self.PreserveCrossSectionShape)
         flowExtensionsFilter.SetExtensionLength(self.ExtensionLength)
         flowExtensionsFilter.SetExtensionRatio(self.ExtensionRatio)
+        if self.ExtensionLengthScaleFactors:
+            extensionLengthScaleFactors = vtk.vtkDoubleArray()
+            for scaleFactor in self.ExtensionLengthScaleFactors:
+                extensionLengthScaleFactors.InsertNextValue(scaleFactor)
+            flowExtensionsFilter.SetExtensionLengthScaleFactors(extensionLengthScaleFactors)
         flowExtensionsFilter.SetExtensionRadius(self.ExtensionRadius)
         flowExtensionsFilter.SetTransitionRatio(self.TransitionRatio)
         flowExtensionsFilter.SetCenterlineNormalEstimationDistanceRatio(self.CenterlineNormalEstimationDistanceRatio)

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataFlowExtensionsFilter.cxx
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataFlowExtensionsFilter.cxx
@@ -204,6 +204,7 @@ vtkvmtkPolyDataFlowExtensionsFilter::vtkvmtkPolyDataFlowExtensionsFilter()
   this->TransitionRatio = 0.5;
   this->ExtensionLength = 0.0;
   this->ExtensionRadius = 1.0;
+  this->ExtensionLengthScaleFactors = NULL;
   this->CenterlineNormalEstimationDistanceRatio = 1.0;
   this->AdaptiveExtensionLength = 1;
   this->AdaptiveExtensionRadius = 1;
@@ -228,6 +229,12 @@ vtkvmtkPolyDataFlowExtensionsFilter::~vtkvmtkPolyDataFlowExtensionsFilter()
     {
     this->BoundaryIds->Delete();
     this->BoundaryIds = NULL;
+    }
+
+  if (this->ExtensionLengthScaleFactors)
+    {
+    this->ExtensionLengthScaleFactors->Delete();
+    this->ExtensionLengthScaleFactors = NULL;
     }
 }
 
@@ -441,6 +448,11 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
     else
       {
       extensionLength = this->ExtensionLength;
+      }
+
+    if (this->ExtensionLengthScaleFactors && i < this->ExtensionLengthScaleFactors->GetNumberOfTuples())
+      {
+      extensionLength *= this->ExtensionLengthScaleFactors->GetValue(i);
       }
 
     double point[3], extensionPoint[3];

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataFlowExtensionsFilter.h
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataFlowExtensionsFilter.h
@@ -44,6 +44,7 @@ Program:   VMTK
 #include "vtkPolyDataAlgorithm.h"
 #include "vtkPolyData.h"
 #include "vtkIdList.h"
+#include "vtkDoubleArray.h"
 #include "vtkvmtkWin32Header.h"
 
 class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataFlowExtensionsFilter : public vtkPolyDataAlgorithm
@@ -79,6 +80,19 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataFlowExtensionsFilter
    */
   vtkSetMacro(ExtensionLength,double);
   vtkGetMacro(ExtensionLength,double);
+  ///@}
+
+  ///@{
+  /**
+   * Set/Get an optional per-boundary scale factor applied to the extension length. Entry i of the
+   * array multiplies the length of the extension grown from boundary i, where i is the boundary's
+   * id in the list of open boundaries extracted from the input (the same ids used in BoundaryIds),
+   * whether that length comes from ExtensionRatio times the boundary's mean radius or from
+   * ExtensionLength. A boundary whose id is beyond the end of the array, or all boundaries when the
+   * array is not set (default, NULL), get a factor of 1.0.
+   */
+  vtkSetObjectMacro(ExtensionLengthScaleFactors,vtkDoubleArray);
+  vtkGetObjectMacro(ExtensionLengthScaleFactors,vtkDoubleArray);
   ///@}
 
   ///@{
@@ -280,6 +294,8 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataFlowExtensionsFilter
   double ExtensionRatio;
   double ExtensionLength;
   double ExtensionRadius;
+
+  vtkDoubleArray* ExtensionLengthScaleFactors;
 
   double TransitionRatio;
   double Sigma;


### PR DESCRIPTION
Add an optional ExtensionLengthScaleFactors array to vtkvmtkPolyDataFlowExtensionsFilter: entry i multiplies the length of the extension grown from boundary i (same ids as BoundaryIds), whether the length comes from ExtensionRatio times the boundary mean radius or from ExtensionLength. Boundaries beyond the end of the array, or all boundaries when the array is not set, keep a factor of 1.0, so existing behavior is unchanged.

Expose the option in vmtkflowextensions as -extensionlengthscalefactors, a list of floats indexed by boundary id.

It is useful for solvers that require different extension length for inflow and outflow or if extension length needs to be tweaked individually.

<img width="1755" height="971" alt="image" src="https://github.com/user-attachments/assets/46e9062d-eb3f-4564-a72e-e342eceb7f02" />
