### PR TITLE
ENH: Allow explicit setting cell entity id of each surface cap, across a flow extension

### DIFF
--- a/tests/test_vmtkScripts/test_vmtkflowextensions.py
+++ b/tests/test_vmtkScripts/test_vmtkflowextensions.py
@@ -86,7 +86,7 @@ def boundary_profiles(surface):
     return profiles
 
 
-def extend(surface, preserveshape, centerlines=None, **kwargs):
+def run_extensions(surface, preserveshape, centerlines=None, **kwargs):
     extensions = flowextensions.vmtkFlowExtensions()
     extensions.Surface = surface
     extensions.PreserveCrossSectionShape = preserveshape
@@ -99,7 +99,11 @@ def extend(surface, preserveshape, centerlines=None, **kwargs):
     for name, value in kwargs.items():
         setattr(extensions, name, value)
     extensions.Execute()
-    return extensions.Surface
+    return extensions
+
+
+def extend(surface, preserveshape, centerlines=None, **kwargs):
+    return run_extensions(surface, preserveshape, centerlines, **kwargs).Surface
 
 
 def test_extensions_are_appended_to_the_surface(elliptic_tube):
@@ -252,3 +256,70 @@ def test_ramp_leaves_a_preserved_cross_section_alone(elliptic_tube):
     # nothing to morph: every ring, the transition included, is the 2:1 boundary outline
     for ratio in extension_ring_ratios(elliptic_tube, surface, numberOfRingPoints, 8):
         assert ratio == pytest.approx(2.0, rel=0.02)
+
+
+def boundary_barycenters(surface):
+    '''The barycenter of each open boundary, in boundary extraction order.'''
+    boundaryExtractor = vtkvmtk.vtkvmtkPolyDataBoundaryExtractor()
+    boundaryExtractor.SetInputData(surface)
+    boundaryExtractor.Update()
+    boundaries = boundaryExtractor.GetOutput()
+    barycenters = []
+    for i in range(boundaries.GetNumberOfCells()):
+        barycenter = [0.0, 0.0, 0.0]
+        vtkvmtk.vtkvmtkBoundaryReferenceSystems.ComputeBoundaryBarycenter(
+            boundaries.GetCell(i).GetPoints(), barycenter)
+        barycenters.append(barycenter)
+    return barycenters
+
+
+def test_output_boundary_ids_account_for_every_boundary(elliptic_tube):
+    extensions = run_extensions(elliptic_tube, 0, AdaptiveExtensionLength=0, ExtensionLength=2.0)
+
+    # the tube has two open boundaries, and each is replaced by the one at the tip of its extension
+    assert len(extensions.OutputBoundaryIds) == len(boundary_barycenters(elliptic_tube)) == 2
+    assert sorted(extensions.OutputBoundaryIds) == [0, 1]
+
+
+def test_output_boundary_ids_point_at_the_boundary_that_replaced_each_one(elliptic_tube):
+    extensions = run_extensions(elliptic_tube, 0, AdaptiveExtensionLength=0, ExtensionLength=2.0)
+
+    before = boundary_barycenters(elliptic_tube)
+    after = boundary_barycenters(extensions.Surface)
+    # the tube is extruded along z and extended along its boundary normals, so a boundary and its
+    # replacement sit on the same axis, the replacement 2 mm further out
+    for boundaryId, outputBoundaryId in enumerate(extensions.OutputBoundaryIds):
+        assert after[outputBoundaryId][0] == pytest.approx(before[boundaryId][0], abs=1e-6)
+        assert after[outputBoundaryId][1] == pytest.approx(before[boundaryId][1], abs=1e-6)
+        assert abs(after[outputBoundaryId][2] - before[boundaryId][2]) == pytest.approx(2.0, rel=0.1)
+
+
+def test_output_boundary_ids_are_not_simply_the_input_ids(elliptic_tube):
+    # Extending one boundary of two leaves the other where it is, so it is met first when the output
+    # is walked for boundaries and the ids no longer line up with the input: the case a caller that
+    # assumed the extraction order was preserved would get wrong.
+    before = boundary_barycenters(elliptic_tube)
+    mappings = []
+    for extendOnly in range(len(before)):
+        boundaryIds = vtk.vtkIdList()
+        boundaryIds.InsertNextId(extendOnly)
+        extensionsFilter = vtkvmtk.vtkvmtkPolyDataFlowExtensionsFilter()
+        extensionsFilter.SetInputData(elliptic_tube)
+        extensionsFilter.SetExtensionModeToUseNormalToBoundary()
+        extensionsFilter.SetAdaptiveExtensionLength(0)
+        extensionsFilter.SetExtensionLength(2.0)
+        extensionsFilter.SetAdaptiveExtensionRadius(1)
+        extensionsFilter.SetBoundaryIds(boundaryIds)
+        extensionsFilter.Update()
+
+        reported = extensionsFilter.GetOutputBoundaryIds()
+        mapping = [reported.GetId(i) for i in range(reported.GetNumberOfIds())]
+        mappings.append(mapping)
+
+        assert sorted(mapping) == list(range(len(before)))
+        after = boundary_barycenters(extensionsFilter.GetOutput())
+        for boundaryId, outputBoundaryId in enumerate(mapping):
+            grown = abs(after[outputBoundaryId][2] - before[boundaryId][2])
+            assert grown == pytest.approx(2.0 if boundaryId == extendOnly else 0.0, abs=0.3)
+
+    assert any(mapping != list(range(len(before))) for mapping in mappings)

--- a/tests/test_vmtkScripts/test_vmtksurfacecapper.py
+++ b/tests/test_vmtkScripts/test_vmtksurfacecapper.py
@@ -14,8 +14,15 @@
 ##       Richard Izzo (Github @rlizzo)
 ##       University at Buffalo
 
+import math
+import os
+
 import pytest
+import vtk
+
+import vmtk.vmtkflowextensions as flowextensions
 import vmtk.vmtksurfacecapper as surfacecapper
+from vmtk import vtkvmtk
 
 
 @pytest.fixture(scope='module')
@@ -67,3 +74,133 @@ def test_smooth_method_with_changing_params(aorta_surface_open_ends, constraint,
     write_surface(capper.Surface)
 
     assert compare_surfaces(capper.Surface, name) == True
+
+
+def open_tube_surface():
+    '''An open-ended circular tube extruded along z, so that it has exactly two boundaries.'''
+    length = 6.0
+    numberOfCircumferentialPoints, numberOfAxialPoints = 32, 8
+    points = vtk.vtkPoints()
+    polys = vtk.vtkCellArray()
+    for i in range(numberOfAxialPoints):
+        z = length * i / (numberOfAxialPoints - 1.0)
+        for j in range(numberOfCircumferentialPoints):
+            angle = 2.0 * math.pi * j / numberOfCircumferentialPoints
+            points.InsertNextPoint(math.cos(angle), math.sin(angle), z)
+    for i in range(numberOfAxialPoints - 1):
+        for j in range(numberOfCircumferentialPoints):
+            p0 = i * numberOfCircumferentialPoints + j
+            p1 = i * numberOfCircumferentialPoints + (j + 1) % numberOfCircumferentialPoints
+            p2 = (i + 1) * numberOfCircumferentialPoints + j
+            p3 = (i + 1) * numberOfCircumferentialPoints + (j + 1) % numberOfCircumferentialPoints
+            polys.InsertNextCell(3, [p0, p1, p3])
+            polys.InsertNextCell(3, [p0, p3, p2])
+    surface = vtk.vtkPolyData()
+    surface.SetPoints(points)
+    surface.SetPolys(polys)
+    return surface
+
+
+@pytest.fixture(scope='module')
+def open_tube():
+    return open_tube_surface()
+
+
+def cap(surface, **kwargs):
+    capper = surfacecapper.vmtkSurfaceCapper()
+    capper.Surface = surface
+    capper.Method = 'centerpoint'
+    capper.Interactive = 0
+    capper.TriangleOutput = 0
+    for name, value in kwargs.items():
+        setattr(capper, name, value)
+    capper.Execute()
+    return capper.Surface
+
+
+def cap_entity_ids(surface):
+    '''The set of entity ids the caps carry, and the id left on the cells that were already there.'''
+    ids = surface.GetCellData().GetArray('CellEntityIds')
+    values = [int(ids.GetTuple1(i)) for i in range(ids.GetNumberOfTuples())]
+    wallId = values[0]
+    return sorted(set(values) - {wallId}), wallId
+
+
+def test_caps_are_numbered_by_boundary_position_by_default(open_tube):
+    capIds, wallId = cap_entity_ids(cap(open_tube))
+
+    assert wallId == 1                  # the CellEntityIdOffset the script defaults to
+    assert capIds == [2, 3]             # boundary index + 1 + offset
+
+
+def test_cell_entity_ids_choose_the_id_of_each_cap(open_tube):
+    capIds, wallId = cap_entity_ids(cap(open_tube, CellEntityIds=[7, 9]))
+
+    assert wallId == 1
+    assert capIds == [7, 9]
+
+
+def test_cell_entity_id_offset_is_not_applied_to_a_chosen_id(open_tube):
+    """The offset is the id of the cells copied from the input and the base the derived cap ids
+    count up from, but a cap named in CellEntityIds takes that id as it stands."""
+    capped = cap(open_tube, CellEntityIdOffset=100, CellEntityIds=[7, -1])
+    capIds, wallId = cap_entity_ids(capped)
+
+    assert wallId == 100                # the cells that were already there
+    assert capIds == [7, 102]           # the chosen id verbatim, and 1 + 1 + 100 for the other
+
+
+def test_cell_entity_ids_fall_back_where_the_caller_gave_none(open_tube):
+    # -1 asks for the positional id, and so does a boundary past the end of the list
+    byPosition, _ = cap_entity_ids(cap(open_tube, CellEntityIds=[-1, -1]))
+    firstOnly, _ = cap_entity_ids(cap(open_tube, CellEntityIds=[7]))
+
+    assert byPosition == [2, 3]
+    assert firstOnly == [3, 7]
+
+
+def test_cell_entity_ids_survive_a_flow_extension(open_tube):
+    '''The point of the two features together: an id chosen for a vessel end still lands on that
+    end after flow extensions have replaced its boundary with one several radii down the branch.'''
+    chosenIds = [7, 9]
+
+    extensions = flowextensions.vmtkFlowExtensions()
+    extensions.Surface = open_tube
+    extensions.Interactive = 0
+    extensions.ExtensionMode = 'boundarynormal'
+    extensions.AdaptiveExtensionLength = 0
+    extensions.ExtensionLength = 3.0
+    extensions.Execute()
+
+    # the extension replaced each boundary, so the ids have to be carried onto the ones that
+    # replaced them before the capper, which knows nothing of the extension, is given them
+    extendedIds = [-1] * len(extensions.OutputBoundaryIds)
+    for boundaryId, outputBoundaryId in enumerate(extensions.OutputBoundaryIds):
+        extendedIds[outputBoundaryId] = chosenIds[boundaryId]
+
+    capIds, wallId = cap_entity_ids(cap(extensions.Surface, CellEntityIds=extendedIds))
+
+    assert capIds == sorted(chosenIds)
+
+    # and each cap really is at the end of the extension grown from the boundary it was chosen for
+    barycenters = []
+    boundaryExtractor = vtkvmtk.vtkvmtkPolyDataBoundaryExtractor()
+    boundaryExtractor.SetInputData(open_tube)
+    boundaryExtractor.Update()
+    for i in range(boundaryExtractor.GetOutput().GetNumberOfCells()):
+        barycenter = [0.0, 0.0, 0.0]
+        vtkvmtk.vtkvmtkBoundaryReferenceSystems.ComputeBoundaryBarycenter(
+            boundaryExtractor.GetOutput().GetCell(i).GetPoints(), barycenter)
+        barycenters.append(barycenter)
+
+    capped = cap(extensions.Surface, CellEntityIds=extendedIds)
+    ids = capped.GetCellData().GetArray('CellEntityIds')
+    for boundaryId, chosenId in enumerate(chosenIds):
+        z = []
+        for cellId in range(capped.GetNumberOfCells()):
+            if int(ids.GetTuple1(cellId)) == chosenId:
+                bounds = capped.GetCell(cellId).GetBounds()
+                z.append(0.5 * (bounds[4] + bounds[5]))
+        capZ = sum(z) / len(z)
+        # 3 mm past the boundary it was chosen for, on that boundary's side of the tube
+        assert abs(capZ - barycenters[boundaryId][2]) == pytest.approx(3.0, rel=0.15)

--- a/vmtkScripts/vmtkflowextensions.py
+++ b/vmtkScripts/vmtkflowextensions.py
@@ -38,6 +38,7 @@ class vmtkFlowExtensions(pypes.pypeScript):
         self.ExtensionLength = 1.0
         self.ExtensionRatio = 10.0
         self.ExtensionLengthScaleFactors = None
+        self.OutputBoundaryIds = None
         self.ExtensionRadius = 1.0
         self.TransitionRatio = 0.25
         self.TargetNumberOfBoundaryPoints = 50
@@ -76,7 +77,8 @@ class vmtkFlowExtensions(pypes.pypeScript):
             ])
         self.SetOutputMembers([
             ['Surface','o','vtkPolyData',1,'','','vmtksurfacewriter'],
-            ['Centerlines','centerlines','vtkPolyData',1]
+            ['Centerlines','centerlines','vtkPolyData',1],
+            ['OutputBoundaryIds','outputboundaryids','int',-1,'','where each open boundary of the input ended up in the output: entry i is the id of the boundary that replaced boundary i, in the boundaries extracted from the output. Extending a boundary replaces it, so this is what a downstream script indexing boundaries by id (vmtksurfacecapper, say) needs to be given the same boundaries back']
             ])
 
     def LabelValidator(self,text):
@@ -196,6 +198,9 @@ class vmtkFlowExtensions(pypes.pypeScript):
         flowExtensionsFilter.Update()
 
         self.Surface = flowExtensionsFilter.GetOutput()
+
+        outputBoundaryIds = flowExtensionsFilter.GetOutputBoundaryIds()
+        self.OutputBoundaryIds = [outputBoundaryIds.GetId(i) for i in range(outputBoundaryIds.GetNumberOfIds())]
 
 
 if __name__=='__main__':

--- a/vmtkScripts/vmtksurfacecapper.py
+++ b/vmtkScripts/vmtksurfacecapper.py
@@ -31,6 +31,7 @@ class vmtkSurfaceCapper(pypes.pypeScript):
         self.TriangleOutput = 1
         self.CellEntityIdsArrayName = 'CellEntityIds'
         self.CellEntityIdOffset = 1
+        self.CellEntityIds = None
         self.Interactive = 1
         self.Method = 'simple'
         self.ConstraintFactor = 1.0
@@ -46,7 +47,8 @@ class vmtkSurfaceCapper(pypes.pypeScript):
             ['Method','method','str',1,'["simple","centerpoint","smooth","annular","concaveannular"]','capping method'],
             ['TriangleOutput','triangle','bool',1,'','toggle triangulation of the output'],
             ['CellEntityIdsArrayName','entityidsarray','str',1,'','name of the array where the id of the caps have to be stored'],
-            ['CellEntityIdOffset','entityidoffset','int',1,'(0,)','offset for entity ids'],
+            ['CellEntityIdOffset','entityidoffset','int',1,'(0,)','base offset for entity ids: the id left on the cells of the input surface, and the base the cap ids count up from, the cap of boundary i getting i+1+entityidoffset. A cap named by cellentityids is the exception, taking that id with no offset applied'],
+            ['CellEntityIds','cellentityids','int',-1,'','the entity id to give the cap of each boundary, indexed by boundary id, in place of the id its position in the list would give it; -1 leaves a boundary with that positional id, as do boundaries beyond the end of the list ("centerpoint" method only). The id is used as it stands, with entityidoffset not added to it, while every boundary not named here still counts up from that offset - so pick an offset that keeps the two apart. Use this to keep the same id on the same inlet or outlet across runs, since the order boundaries are extracted in depends on how the surface happens to be meshed; for a surface that has been extended first, vmtkflowextensions reports in outputboundaryids where each boundary went'],
             ['ConstraintFactor','constraint','float',1,'','amount of influence of the shape of the surface near the boundary on the shape of the cap ("smooth" method only)'],
             ['NumberOfRings','rings','int',1,'(0,)','number of rings composing the cap ("smooth" method only)'],
             ['Interactive','interactive','bool',1],
@@ -172,6 +174,14 @@ class vmtkSurfaceCapper(pypes.pypeScript):
 
         if self.Interactive:
             capper.SetBoundaryIds(boundaryIds)
+        if self.CellEntityIds:
+            if not hasattr(capper,'SetBoundaryCellEntityIds'):
+                self.PrintError('Error: cellentityids is only supported by the centerpoint capping method.')
+            else:
+                boundaryCellEntityIds = vtk.vtkIdList()
+                for cellEntityId in self.CellEntityIds:
+                    boundaryCellEntityIds.InsertNextId(cellEntityId)
+                capper.SetBoundaryCellEntityIds(boundaryCellEntityIds)
         capper.SetCellEntityIdsArrayName(self.CellEntityIdsArrayName)
         capper.SetCellEntityIdOffset(self.CellEntityIdOffset)
         capper.Update()

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkCapPolyData.cxx
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkCapPolyData.cxx
@@ -26,6 +26,7 @@ Version:   $Revision: 1.5 $
 #include "vtkCellArray.h"
 #include "vtkPointData.h"
 #include "vtkCellData.h"
+#include "vtkDataArray.h"
 #include "vtkMath.h"
 #include "vtkPolyLine.h"
 #include "vtkLine.h"
@@ -45,6 +46,7 @@ vtkvmtkCapPolyData::vtkvmtkCapPolyData()
   this->InPlaneDisplacement = 1E-1;
   this->CapCenterIds = NULL;
   this->CellEntityIdsArrayName = NULL;
+  this->BoundaryCellEntityIds = NULL;
   this->CellEntityIdOffset = 1;
 }
 
@@ -64,6 +66,11 @@ vtkvmtkCapPolyData::~vtkvmtkCapPolyData()
     {
     delete[] this->CellEntityIdsArrayName;
     this->CellEntityIdsArrayName = NULL;
+    }
+  if (this->BoundaryCellEntityIds)
+    {
+    this->BoundaryCellEntityIds->Delete();
+    this->BoundaryCellEntityIds = NULL;
     }
 }
 
@@ -122,6 +129,10 @@ int vtkvmtkCapPolyData::RequestData(
       }
     }
 
+  // Ids the caller chose for the boundaries, used in place of the index-derived ones when deciding
+  // a cap's cell entity id (see BoundaryCellEntityIds).
+  bool useBoundaryCellEntityIds = markCells && this->BoundaryCellEntityIds;
+
   // Execute
   boundaryExtractor->SetInputData(input);
   boundaryExtractor->Update();
@@ -175,6 +186,14 @@ int vtkvmtkCapPolyData::RequestData(
     this->CapCenterIds->SetId(i,barycenterId);
 
     vtkIdType numberOfBoundaryPoints = boundary->GetNumberOfPoints();
+
+    vtkIdType capCellEntityId = i + 1 + this->CellEntityIdOffset;
+    if (useBoundaryCellEntityIds && i < this->BoundaryCellEntityIds->GetNumberOfIds()
+        && this->BoundaryCellEntityIds->GetId(i) >= 0)
+      {
+      capCellEntityId = this->BoundaryCellEntityIds->GetId(i);
+      }
+
     for (j=0; j<numberOfBoundaryPoints; j++)
       {
       trianglePoints[0] = static_cast<vtkIdType>(boundaries->GetPointData()->GetScalars()->GetTuple1(boundary->GetPointId(j)));
@@ -185,7 +204,7 @@ int vtkvmtkCapPolyData::RequestData(
 
       if (markCells)
         {
-        cellEntityIdsArray->InsertNextValue(i+1+this->CellEntityIdOffset);
+        cellEntityIdsArray->InsertNextValue(capCellEntityId);
         }
 
       }

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkCapPolyData.h
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkCapPolyData.h
@@ -64,9 +64,10 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkCapPolyData : public vtkPoly
   ///@}
 
   ///@{
-  /*! Set/Get the name of the cell data array used to tag the newly created cap triangles with an
-      integer id, one distinct value per capped boundary (offset by CellEntityIdOffset, then further
-      offset by boundary index + 1). If the array already exists on the input, existing cell values
+  /*! Set/Get the name of the cell data array used to tag the cells of the output with an integer
+      id: the cells copied from the input all get CellEntityIdOffset, and each cap gets a distinct
+      id of its own, (boundary index + 1 + CellEntityIdOffset) by default or whatever
+      BoundaryCellEntityIds asks for. If the array already exists on the input, existing cell values
       are preserved and only the new cap cells are appended with the new tag. If left NULL (default),
       no cell entity id array is created. Commonly named "CellEntityIds". */
   vtkSetStringMacro(CellEntityIdsArrayName);
@@ -74,10 +75,39 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkCapPolyData : public vtkPoly
   ///@}
 
   ///@{
-  /*! Set/Get the base offset added to the ids written into CellEntityIdsArrayName. The id assigned
-      to the cap of the i-th processed boundary is (i + 1 + CellEntityIdOffset). Default: 1. */
+  /*! Set/Get the base offset of the ids written into CellEntityIdsArrayName. It is both the id left
+      on the cells copied from the input -- the wall, in a vascular surface -- and the base the cap
+      ids count up from: the cap of the i-th processed boundary gets (i + 1 + CellEntityIdOffset),
+      so the caps occupy the ids above the wall. A cap named by BoundaryCellEntityIds is the
+      exception: it takes that id as it stands, with no offset applied. Default: 1. */
   vtkSetMacro(CellEntityIdOffset,int);
   vtkGetMacro(CellEntityIdOffset,int);
+  ///@}
+
+  ///@{
+  /*! Set/Get the cell entity id to write into CellEntityIdsArrayName for the cap of each boundary,
+      in place of the (boundary index + 1 + CellEntityIdOffset) that boundary's position in the list
+      would give it. Indexed consistently with BoundaryIds -- entry i belongs to boundary i of the
+      list of open boundaries extracted from the input. A boundary whose entry is negative or beyond
+      the end of the list keeps the index-derived id, as does every boundary when this is not set
+      (default, NULL). Requires CellEntityIdsArrayName to be set; ignored otherwise.
+
+      The id given here is used as it stands: CellEntityIdOffset is not added to it. The offset still
+      applies to everything it is not asked about, so the three can appear side by side in one
+      output -- with an offset of 100 and entries [7, -1], the cells copied from the input get 100,
+      the first cap gets 7, and the second, left to its position, gets 102. Choosing an offset that
+      puts the derived ids clear of the chosen ones is what keeps a boundary the caller did not
+      account for from colliding with one it did.
+
+      The point of all this is that the boundary list is ordered by the boundary extractor, so a
+      cap's id otherwise depends on how the input happens to be meshed and on which other boundaries
+      exist, which is fragile for a caller that has to keep the same face numbering across runs. Note
+      that the ids here are indices into *this* filter's extraction of *its own* input: a caller that
+      grew flow extensions first has to carry its ids across that change with
+      vtkvmtkPolyDataFlowExtensionsFilter::GetOutputBoundaryIds(), since extending a boundary
+      replaces it and reorders the extraction. */
+  vtkSetObjectMacro(BoundaryCellEntityIds,vtkIdList);
+  vtkGetObjectMacro(BoundaryCellEntityIds,vtkIdList);
   ///@}
 
   ///@{
@@ -112,6 +142,7 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkCapPolyData : public vtkPoly
 
   vtkIdList* BoundaryIds;
   char* CellEntityIdsArrayName;
+  vtkIdList* BoundaryCellEntityIds;
   int CellEntityIdOffset;
 
   double Displacement;

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataFlowExtensionsFilter.cxx
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataFlowExtensionsFilter.cxx
@@ -28,7 +28,9 @@ Version:   $Revision: 1.12 $
 #include "vtkTransform.h"
 #include "vtkPolyLine.h"
 #include "vtkPointData.h"
+#include "vtkDataArray.h"
 #include "vtkDoubleArray.h"
+#include "vtkSmartPointer.h"
 #include "vtkIntArray.h"
 #include "vtkMath.h"
 #include "vtkCellArray.h"
@@ -212,6 +214,7 @@ vtkvmtkPolyDataFlowExtensionsFilter::vtkvmtkPolyDataFlowExtensionsFilter()
   this->NumberOfBoundaryPoints = 50;
   this->AdaptiveNumberOfBoundaryPoints = 0;
   this->BoundaryIds = NULL;
+  this->OutputBoundaryIds = NULL;
   this->Sigma = 1.0;
   this->SetExtensionModeToUseCenterlineDirection();
   this->SetInterpolationModeToThinPlateSpline();
@@ -235,6 +238,12 @@ vtkvmtkPolyDataFlowExtensionsFilter::~vtkvmtkPolyDataFlowExtensionsFilter()
     {
     this->ExtensionLengthScaleFactors->Delete();
     this->ExtensionLengthScaleFactors = NULL;
+    }
+
+  if (this->OutputBoundaryIds)
+    {
+    this->OutputBoundaryIds->Delete();
+    this->OutputBoundaryIds = NULL;
     }
 }
 
@@ -266,12 +275,32 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
   outputPoints->DeepCopy(input->GetPoints());
   outputPolys->DeepCopy(input->GetPolys());
 
+  if (this->OutputBoundaryIds)
+    {
+    this->OutputBoundaryIds->Delete();
+    this->OutputBoundaryIds = NULL;
+    }
+
   vtkNew<vtkvmtkPolyDataBoundaryExtractor> boundaryExtractor;
   boundaryExtractor->SetInputData(input);
 
   boundaryExtractor->Update();
 
   vtkPolyData* boundaries = boundaryExtractor->GetOutput();
+
+  // One slot per input boundary, holding an output point that lies on whatever boundary replaces
+  // it. The points copied above keep their input ids, so a boundary left alone is already answered
+  // by its own first point; a boundary that is extended is answered by its new tip ring below.
+  // These are only a means to the boundary ids published at the end (see OutputBoundaryIds).
+  std::vector<vtkIdType> replacementPointIds(boundaries->GetNumberOfCells(),-1);
+  for (vtkIdType boundaryIndex=0; boundaryIndex<boundaries->GetNumberOfCells(); boundaryIndex++)
+    {
+    vtkPolyLine* inputBoundary = vtkPolyLine::SafeDownCast(boundaries->GetCell(boundaryIndex));
+    if (inputBoundary && inputBoundary->GetNumberOfPoints() > 0)
+      {
+      replacementPointIds[boundaryIndex] = static_cast<vtkIdType>(vtkMath::Round(boundaries->GetPointData()->GetScalars()->GetComponent(inputBoundary->GetPointId(0),0)));
+      }
+    }
 
   vtkNew<vtkPolyData> centerlines;
   vtkNew<vtkvmtkPolyBallLine> tube;
@@ -323,6 +352,7 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
       {
       boundaryIds->InsertNextId(static_cast<vtkIdType>(vtkMath::Round(boundaries->GetPointData()->GetScalars()->GetComponent(boundary->GetPointId(j),0))));
       }
+
     
     double barycenter[3];
     double normal[3], outwardNormal[3];
@@ -450,9 +480,12 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
       extensionLength = this->ExtensionLength;
       }
 
-    if (this->ExtensionLengthScaleFactors && i < this->ExtensionLengthScaleFactors->GetNumberOfTuples())
+    if (this->ExtensionLengthScaleFactors)
       {
-      extensionLength *= this->ExtensionLengthScaleFactors->GetValue(i);
+      if (i < this->ExtensionLengthScaleFactors->GetNumberOfTuples())
+        {
+        extensionLength *= this->ExtensionLengthScaleFactors->GetValue(i);
+        }
       }
 
     double point[3], extensionPoint[3];
@@ -878,10 +911,58 @@ int vtkvmtkPolyDataFlowExtensionsFilter::RequestData(
       previousBoundaryIds->DeepCopy(newBoundaryIds);
       }
 
+    // previousBoundaryIds is now the last ring laid down, which is the new open boundary at the tip
+    // of this extension - or, when the extension was too short for a single layer, still the ids of
+    // the boundary this started from, which is then the right answer too.
+    if (previousBoundaryIds->GetNumberOfIds() > 0)
+      {
+      replacementPointIds[i] = previousBoundaryIds->GetId(0);
+      }
     }
 
   output->SetPoints(outputPoints);
   output->SetPolys(outputPolys);
+
+  // Where each input boundary ended up, as an id into the output's own boundary extraction, so that
+  // a downstream filter indexing boundaries the same way can be told which is which. The output is
+  // extracted here rather than left to the caller because only this filter knows which of the new
+  // points belong to which extension.
+  this->OutputBoundaryIds = vtkIdList::New();
+  this->OutputBoundaryIds->SetNumberOfIds(boundaries->GetNumberOfCells());
+  for (vtkIdType boundaryIndex=0; boundaryIndex<boundaries->GetNumberOfCells(); boundaryIndex++)
+    {
+    this->OutputBoundaryIds->SetId(boundaryIndex,-1);
+    }
+
+  vtkNew<vtkvmtkPolyDataBoundaryExtractor> outputBoundaryExtractor;
+  outputBoundaryExtractor->SetInputData(output);
+  outputBoundaryExtractor->Update();
+  vtkPolyData* outputBoundaries = outputBoundaryExtractor->GetOutput();
+  vtkDataArray* outputBoundaryPointIds = outputBoundaries->GetPointData()->GetScalars();
+  if (outputBoundaryPointIds)
+    {
+    for (vtkIdType outputBoundaryIndex=0; outputBoundaryIndex<outputBoundaries->GetNumberOfCells(); outputBoundaryIndex++)
+      {
+      vtkPolyLine* outputBoundary = vtkPolyLine::SafeDownCast(outputBoundaries->GetCell(outputBoundaryIndex));
+      if (!outputBoundary)
+        {
+        continue;
+        }
+      vtkNew<vtkIdList> outputBoundaryIds;
+      for (vtkIdType j2=0; j2<outputBoundary->GetNumberOfPoints(); j2++)
+        {
+        outputBoundaryIds->InsertNextId(static_cast<vtkIdType>(vtkMath::Round(outputBoundaryPointIds->GetTuple1(outputBoundary->GetPointId(j2)))));
+        }
+      for (vtkIdType boundaryIndex=0; boundaryIndex<static_cast<vtkIdType>(replacementPointIds.size()); boundaryIndex++)
+        {
+        if (replacementPointIds[boundaryIndex] >= 0
+            && outputBoundaryIds->IsId(replacementPointIds[boundaryIndex]) != -1)
+          {
+          this->OutputBoundaryIds->SetId(boundaryIndex,outputBoundaryIndex);
+          }
+        }
+      }
+    }
 
   return 1;
 }

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataFlowExtensionsFilter.h
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataFlowExtensionsFilter.h
@@ -84,12 +84,13 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataFlowExtensionsFilter
 
   ///@{
   /**
-   * Set/Get an optional per-boundary scale factor applied to the extension length. Entry i of the
-   * array multiplies the length of the extension grown from boundary i, where i is the boundary's
-   * id in the list of open boundaries extracted from the input (the same ids used in BoundaryIds),
-   * whether that length comes from ExtensionRatio times the boundary's mean radius or from
-   * ExtensionLength. A boundary whose id is beyond the end of the array, or all boundaries when the
-   * array is not set (default, NULL), get a factor of 1.0.
+   * Set/Get an optional per-boundary scale factor applied to the extension length, whether that
+   * length comes from ExtensionRatio times the boundary's mean radius or from ExtensionLength.
+   *
+   * Entry i multiplies the length of the extension grown from boundary i, where i is the boundary's
+   * id in the list of open boundaries extracted from the input (the same ids used in BoundaryIds).
+   * A boundary whose id is beyond the end of the array, and every boundary when the array is not
+   * set (default, NULL), get a factor of 1.0.
    */
   vtkSetObjectMacro(ExtensionLengthScaleFactors,vtkDoubleArray);
   vtkGetObjectMacro(ExtensionLengthScaleFactors,vtkDoubleArray);
@@ -216,6 +217,23 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataFlowExtensionsFilter
   vtkGetObjectMacro(BoundaryIds,vtkIdList);
   ///@}
 
+  /**
+   * Get where each open boundary of the input ended up in the output: entry i is the id of the
+   * boundary of the output surface that replaced boundary i of the input, in the list of open
+   * boundaries extracted from the output -- so that a downstream filter that indexes boundaries the
+   * way this one does (vtkvmtkCapPolyData and the other cappers, through their own BoundaryIds) can
+   * still be told which boundary is which.
+   *
+   * Extending a boundary replaces it: the new open boundary at the tip of the extension is made of
+   * new points, several radii from the original, and the boundary extraction order of the output is
+   * not the input's. A boundary that was not extended still appears here, mapped to wherever it now
+   * falls in that order. Entry i is -1 if boundary i has no counterpart in the output.
+   *
+   * Indexed consistently with BoundaryIds, like the input boundary ids everywhere else in this
+   * filter. Valid only after Update() has been called.
+   */
+  vtkGetObjectMacro(OutputBoundaryIds,vtkIdList);
+
   ///@{
   /**
    * Set/Get the method used to compute the direction along which each boundary is extended: either
@@ -314,6 +332,8 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataFlowExtensionsFilter
   int InterpolationMode;
 
   vtkIdList* BoundaryIds;
+
+  vtkIdList* OutputBoundaryIds;
 
   private:
   vtkvmtkPolyDataFlowExtensionsFilter(const vtkvmtkPolyDataFlowExtensionsFilter&);  // Not implemented.


### PR DESCRIPTION
vtkvmtkCapPolyData numbers each cap from the position of the boundary it closes in the list the boundary extractor filter returns. That order is a result of the input's cell and point numbering, so it depends on how the surface happens to be meshed and on which other boundaries exist. However, for some workflows it may be necessary to assign a predetermined cell ID to a cap and this assignment should also work robustly when flow extensions are added.

vtkvmtkCapPolyData takes BoundaryCellEntityIds, indexed consistently with BoundaryIds like everything else in these filters: entry i is the id to write into CellEntityIdsArrayName for the cap of boundary i, and a negative or missing entry keeps the id that boundary's position would give it. A chosen id is used as it stands, with CellEntityIdOffset not added to it, while the offset still lands on the cells copied from the input and on any boundary left to its positional id; the documentation of all three spells that out, since it means an output can carry ids from both rules at once.

Growing a flow extension replaces a boundary with a new one at the tip of the extension, several radii down the branch and made of new points, and the extraction order of the output is not the input's - a boundary left unextended is met before the extensions appended after it. So vtkvmtkPolyDataFlowExtensionsFilter now reports, in GetOutputBoundaryIds(), where each of its input boundaries ended up in its own output. That is the filter's own knowledge: nothing else can relate the two, and a caller that assumed the order was preserved would silently mislabel a face.

Both are exposed to the pypes scripts, so the pair can be used from a pipeline: vmtkflowextensions reports the mapping in outputboundaryids, and vmtksurfacecapper takes the ids in cellentityids for its centerpoint method.

Tests cover the mapping accounting for every boundary and pointing at the boundary that replaced each one, the case where it is not the identity (extending one boundary of two), the capper honouring the ids, falling back where it is given none, and leaving a chosen id free of the offset, and the two together: an id chosen for a vessel end still lands on that end after its boundary has been replaced.