### PR TITLE
Let a boundary's label be its cap's id

### DIFF
--- a/tests/test_vmtkScripts/test_vmtkcappers.py
+++ b/tests/test_vmtkScripts/test_vmtkcappers.py
@@ -140,17 +140,31 @@ def test_cap_takes_the_id_chosen_for_the_boundary_it_closes(capperClass):
 
 
 @pytest.mark.parametrize('capperClass', SINGLE_BOUNDARY_CAPPERS)
-def test_cap_keeps_its_positional_id_where_no_id_was_chosen(capperClass):
-    """An entry of -1 is no entry at all: that boundary falls back to the id its position gives
-    it, so a caller can name the boundaries it cares about and leave the rest alone."""
+def test_cap_takes_the_boundary_label_when_no_id_is_chosen(capperClass):
+    """The label is the boundary's name, so it is the cap's id when the caller names none: an
+    id has to be asked for only where it should differ from the label."""
+    surface, labels = labelled(tube_surface())
+
+    ids = cap_ids(capperClass(), surface, useLabels=True)
+
+    # 0 is the wall here as well as the label of the first boundary, so both caps are accounted
+    # for by their labels
+    assert ids == sorted(set([0]) | set(labels))
+
+
+@pytest.mark.parametrize('capperClass', SINGLE_BOUNDARY_CAPPERS)
+def test_cap_falls_back_to_its_label_where_no_id_was_chosen_for_it(capperClass):
+    """An entry of -1 is no entry at all: that cap keeps its own label, so a caller can choose
+    ids for the ends it cares about and leave the rest named after their boundaries."""
     surface, labels = labelled(tube_surface())
 
     ids = cap_ids(capperClass(), surface, useLabels=True,
                   boundaryCellEntityIds=chosen_ids({labels[0]: 55}))
 
-    # the wall, the cap that was named, and one still numbered by its position
+    # the wall, the cap that was named, and one carrying its own label
     assert len(ids) == 3
     assert 55 in ids
+    assert labels[1] in ids
 
 
 @pytest.mark.parametrize('capperClass', SINGLE_BOUNDARY_CAPPERS)

--- a/tests/test_vmtkScripts/test_vmtksurfacecapper.py
+++ b/tests/test_vmtkScripts/test_vmtksurfacecapper.py
@@ -168,7 +168,7 @@ def test_cap_takes_the_id_chosen_for_its_label(tube):
     assert capZ[107] == pytest.approx(TUBE_LENGTH)
 
 
-def test_cap_keeps_its_positional_id_where_none_was_chosen(tube):
+def test_cap_keeps_its_label_where_no_id_was_chosen(tube):
     wallCellCount = tube.GetNumberOfCells()
     surface = labeled(tube, [0, 1])
 
@@ -176,11 +176,12 @@ def test_cap_keeps_its_positional_id_where_none_was_chosen(tube):
                  BoundaryCellEntityIds=[-1, 55])
 
     capZ = cap_z_by_entity_id(capped, wallCellCount)
-    # the boundary labeled 1 took the id it was given, and the one labeled 0, whose entry is
-    # negative, kept the id its position gives it: 0 + 1 + CellEntityIdOffset
+    # the boundary labeled 1 took the id it was given; the one labeled 0, whose entry is
+    # negative, kept its own label, which names it just as well
     assert 55 in capZ
     assert capZ[55] == pytest.approx(TUBE_LENGTH)
-    assert 0 + 1 + 1 in capZ
+    assert 0 in capZ
+    assert capZ[0] == pytest.approx(0.0)
 
 
 def test_a_chosen_id_is_free_of_the_offset(tube):

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkCapPolyData.cxx
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkCapPolyData.cxx
@@ -243,15 +243,17 @@ int vtkvmtkCapPolyData::RequestData(
         // An id the caller chose for this boundary is used as it stands; CellEntityIdOffset is
         // what moves the ids this filter derives itself out of the way of the input's, and has
         // no business shifting one that was picked deliberately.
-        vtkIdType capCellEntityId = i+1+this->CellEntityIdOffset;
-        if (this->BoundaryCellEntityIds)
+        // With the labels in use the boundary's label is its name, so it is also the cap's id
+        // unless the caller chose another: a label is as deliberate as an entry in
+        // BoundaryCellEntityIds, and neither is shifted by CellEntityIdOffset. Without them
+        // there is nothing to go on but the boundary's position.
+        vtkIdType boundaryId = useBoundaryLabels ? boundaryLabels->GetId(i) : i;
+        vtkIdType capCellEntityId = useBoundaryLabels ? boundaryId : i+1+this->CellEntityIdOffset;
+        if (this->BoundaryCellEntityIds
+            && boundaryId < this->BoundaryCellEntityIds->GetNumberOfTuples()
+            && this->BoundaryCellEntityIds->GetValue(boundaryId) >= 0)
           {
-          vtkIdType boundaryId = useBoundaryLabels ? boundaryLabels->GetId(i) : i;
-          if (boundaryId < this->BoundaryCellEntityIds->GetNumberOfTuples()
-              && this->BoundaryCellEntityIds->GetValue(boundaryId) >= 0)
-            {
-            capCellEntityId = this->BoundaryCellEntityIds->GetValue(boundaryId);
-            }
+          capCellEntityId = this->BoundaryCellEntityIds->GetValue(boundaryId);
           }
         cellEntityIdsArray->InsertNextValue(capCellEntityId);
         }

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkCapPolyData.h
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkCapPolyData.h
@@ -107,8 +107,10 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkCapPolyData : public vtkPoly
       the way boundary ids are indexed everywhere else here (see BoundaryIds): entry i is the id
       given to the cap closing the boundary whose id is i.
 
-      An id beyond the end of the array, or one whose entry is negative, keeps the id the
-      boundary's position would have given it, so an output can carry ids from both rules at once.
+      An id beyond the end of the array, or one whose entry is negative, is no entry at all: with
+      the labels in use that cap keeps its boundary's label, which names it just as well, and
+      without them the id its position would have given it. An output can carry ids from both
+      rules at once.
       An id chosen here is used as it stands, with CellEntityIdOffset not added to it, while the
       offset still lands on the cells copied from the input and on any boundary left to its
       positional id.

--- a/vtkVmtk/Contrib/vtkvmtkConcaveAnnularCapPolyData.cxx
+++ b/vtkVmtk/Contrib/vtkvmtkConcaveAnnularCapPolyData.cxx
@@ -464,7 +464,7 @@ int vtkvmtkConcaveAnnularCapPolyData::RequestData(
         vtkIdType boundaryId = useBoundaryLabels ? boundaryLabels->GetId(i0) : i0;
         vtkIdType partnerBoundaryId = useBoundaryLabels ? boundaryLabels->GetId(i1) : i1;
         cellEntityIdsArray->InsertNextValue(static_cast<int>(
-          this->PairCapCellEntityId(pairingCount + 1 + this->CellEntityIdOffset,boundaryId,partnerBoundaryId)));
+          this->PairCapCellEntityId(pairingCount + 1 + this->CellEntityIdOffset,boundaryId,partnerBoundaryId,useBoundaryLabels)));
         }
       }
     } // end for loop over boundary pairs
@@ -482,11 +482,17 @@ int vtkvmtkConcaveAnnularCapPolyData::RequestData(
   return 1;
 }
 
-vtkIdType vtkvmtkConcaveAnnularCapPolyData::PairCapCellEntityId(vtkIdType positionalId, vtkIdType boundaryId, vtkIdType partnerBoundaryId)
+vtkIdType vtkvmtkConcaveAnnularCapPolyData::PairCapCellEntityId(vtkIdType positionalId, vtkIdType boundaryId, vtkIdType partnerBoundaryId, bool useBoundaryLabels)
 {
+  // With the labels in use a boundary's label is its name, so the pair is named by the
+  // lower of its two labels -- the inner boundary, when the surface was labelled in annular
+  // mode -- unless the caller chose an id for it. Without them there is only position.
+  vtkIdType unchosenId = useBoundaryLabels
+    ? (boundaryId < partnerBoundaryId ? boundaryId : partnerBoundaryId)
+    : positionalId;
   if (!this->BoundaryCellEntityIds)
     {
-    return positionalId;
+    return unchosenId;
     }
 
   vtkIdType lowerId = boundaryId < partnerBoundaryId ? boundaryId : partnerBoundaryId;
@@ -511,7 +517,7 @@ vtkIdType vtkvmtkConcaveAnnularCapPolyData::PairCapCellEntityId(vtkIdType positi
     {
     return higherEntry;
     }
-  return positionalId;
+  return unchosenId;
 }
 
 void vtkvmtkConcaveAnnularCapPolyData::PrintSelf(std::ostream& os, vtkIndent indent)

--- a/vtkVmtk/Contrib/vtkvmtkConcaveAnnularCapPolyData.h
+++ b/vtkVmtk/Contrib/vtkvmtkConcaveAnnularCapPolyData.h
@@ -121,8 +121,9 @@ class VTK_VMTK_CONTRIB_EXPORT vtkvmtkConcaveAnnularCapPolyData : public vtkPolyD
   virtual int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
 
   /// The id to tag the cap closing a pair of boundaries with: the entry of whichever of the two
-  /// has one, the lower boundary id winning a disagreement, or the positional id.
-  vtkIdType PairCapCellEntityId(vtkIdType positionalId, vtkIdType boundaryId, vtkIdType partnerBoundaryId);
+  /// has one, the lower boundary id winning a disagreement; failing that the pair's lower
+  /// boundary id with the labels in use, and the positional id without them.
+  vtkIdType PairCapCellEntityId(vtkIdType positionalId, vtkIdType boundaryId, vtkIdType partnerBoundaryId, bool useBoundaryLabels);
 
   vtkIdList* BoundaryIds;
   char* BoundaryLabelsArrayName;

--- a/vtkVmtk/Misc/vtkvmtkAnnularCapPolyData.cxx
+++ b/vtkVmtk/Misc/vtkvmtkAnnularCapPolyData.cxx
@@ -348,7 +348,7 @@ int vtkvmtkAnnularCapPolyData::RequestData(
         vtkIdType boundaryId = useBoundaryLabels ? boundaryLabels->GetId(i) : i;
         vtkIdType partnerBoundaryId = useBoundaryLabels ? boundaryLabels->GetId(boundaryPairings->GetId(i)) : boundaryPairings->GetId(i);
         cellEntityIdsArray->InsertNextValue(
-          this->PairCapCellEntityId(i+1+this->CellEntityIdOffset,boundaryId,partnerBoundaryId));
+          this->PairCapCellEntityId(i+1+this->CellEntityIdOffset,boundaryId,partnerBoundaryId,useBoundaryLabels));
         }
       }
 
@@ -377,11 +377,17 @@ int vtkvmtkAnnularCapPolyData::RequestData(
   return 1;
 }
 
-vtkIdType vtkvmtkAnnularCapPolyData::PairCapCellEntityId(vtkIdType positionalId, vtkIdType boundaryId, vtkIdType partnerBoundaryId)
+vtkIdType vtkvmtkAnnularCapPolyData::PairCapCellEntityId(vtkIdType positionalId, vtkIdType boundaryId, vtkIdType partnerBoundaryId, bool useBoundaryLabels)
 {
+  // With the labels in use a boundary's label is its name, so the pair is named by the
+  // lower of its two labels -- the inner boundary, when the surface was labelled in annular
+  // mode -- unless the caller chose an id for it. Without them there is only position.
+  vtkIdType unchosenId = useBoundaryLabels
+    ? (boundaryId < partnerBoundaryId ? boundaryId : partnerBoundaryId)
+    : positionalId;
   if (!this->BoundaryCellEntityIds)
     {
-    return positionalId;
+    return unchosenId;
     }
 
   vtkIdType lowerId = boundaryId < partnerBoundaryId ? boundaryId : partnerBoundaryId;
@@ -408,7 +414,7 @@ vtkIdType vtkvmtkAnnularCapPolyData::PairCapCellEntityId(vtkIdType positionalId,
     {
     return higherEntry;
     }
-  return positionalId;
+  return unchosenId;
 }
 
 void vtkvmtkAnnularCapPolyData::PrintSelf(std::ostream& os, vtkIndent indent)

--- a/vtkVmtk/Misc/vtkvmtkAnnularCapPolyData.h
+++ b/vtkVmtk/Misc/vtkvmtkAnnularCapPolyData.h
@@ -130,8 +130,9 @@ class VTK_VMTK_MISC_EXPORT vtkvmtkAnnularCapPolyData : public vtkPolyDataAlgorit
   virtual int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
 
   /// The id to tag the cap closing a pair of boundaries with: the entry of whichever of the two
-  /// has one, the lower boundary id winning a disagreement, or the positional id.
-  vtkIdType PairCapCellEntityId(vtkIdType positionalId, vtkIdType boundaryId, vtkIdType partnerBoundaryId);
+  /// has one, the lower boundary id winning a disagreement; failing that the pair's lower
+  /// boundary id with the labels in use, and the positional id without them.
+  vtkIdType PairCapCellEntityId(vtkIdType positionalId, vtkIdType boundaryId, vtkIdType partnerBoundaryId, bool useBoundaryLabels);
 
   vtkIdList* BoundaryIds;
   char* BoundaryLabelsArrayName;

--- a/vtkVmtk/Misc/vtkvmtkSimpleCapPolyData.cxx
+++ b/vtkVmtk/Misc/vtkvmtkSimpleCapPolyData.cxx
@@ -151,7 +151,9 @@ int vtkvmtkSimpleCapPolyData::RequestData(
       // An id the caller chose for this boundary is used as it stands; CellEntityIdOffset is
       // what moves the ids this filter derives itself out of the way of the input's, and has
       // no business shifting one that was picked deliberately.
-      vtkIdType capCellEntityId = i+1+this->CellEntityIdOffset;
+      // With the labels in use the boundary's label is its name, so it is also the cap's id
+      // unless the caller chose another; neither is shifted by CellEntityIdOffset.
+      vtkIdType capCellEntityId = useBoundaryLabels ? boundaryId : i+1+this->CellEntityIdOffset;
       if (this->BoundaryCellEntityIds
           && boundaryId < this->BoundaryCellEntityIds->GetNumberOfTuples()
           && this->BoundaryCellEntityIds->GetValue(boundaryId) >= 0)

--- a/vtkVmtk/Misc/vtkvmtkSimpleCapPolyData.h
+++ b/vtkVmtk/Misc/vtkvmtkSimpleCapPolyData.h
@@ -109,8 +109,9 @@ class VTK_VMTK_MISC_EXPORT vtkvmtkSimpleCapPolyData : public vtkPolyDataAlgorith
    * the way boundary ids are indexed everywhere else here (see BoundaryIds): entry i is the id
    * given to the cap closing the boundary whose id is i.
    *
-   * An id beyond the end of the array, or one whose entry is negative, keeps the id the
-   * boundary's position would have given it, so an output can carry ids from both rules at once.
+   * An id beyond the end of the array, or one whose entry is negative, is no entry at all: with
+   * the labels in use that cap keeps its boundary's label, which names it just as well, and
+   * without them the id its position would have given it.
    * An id chosen here is used as it stands, with CellEntityIdOffset not added to it, while the
    * offset still lands on the cells copied from the input and on any boundary left to its
    * positional id.

--- a/vtkVmtk/Misc/vtkvmtkSmoothCapPolyData.cxx
+++ b/vtkVmtk/Misc/vtkvmtkSmoothCapPolyData.cxx
@@ -267,7 +267,7 @@ int vtkvmtkSmoothCapPolyData::RequestData(
         newPolyIds->Delete();
         if (markCells)
           {
-          cellEntityIdsArray->InsertNextValue(this->CapCellEntityId(boundaryId,capBoundaryId));
+          cellEntityIdsArray->InsertNextValue(this->CapCellEntityId(boundaryId,capBoundaryId,useBoundaryLabels));
           }
         }
       }
@@ -276,7 +276,7 @@ int vtkvmtkSmoothCapPolyData::RequestData(
 
     if (markCells)
       {
-      cellEntityIdsArray->InsertNextValue(this->CapCellEntityId(boundaryId,capBoundaryId));
+      cellEntityIdsArray->InsertNextValue(this->CapCellEntityId(boundaryId,capBoundaryId,useBoundaryLabels));
       }
 
     boundaryPointIds->Delete();
@@ -304,7 +304,7 @@ int vtkvmtkSmoothCapPolyData::RequestData(
   return 1;
 }
 
-vtkIdType vtkvmtkSmoothCapPolyData::CapCellEntityId(vtkIdType boundaryIndex, vtkIdType boundaryId)
+vtkIdType vtkvmtkSmoothCapPolyData::CapCellEntityId(vtkIdType boundaryIndex, vtkIdType boundaryId, bool useBoundaryLabels)
 {
   // An id the caller chose for this boundary is used as it stands; CellEntityIdOffset is what
   // moves the ids this filter derives itself out of the way of the input's, and has no business
@@ -314,6 +314,12 @@ vtkIdType vtkvmtkSmoothCapPolyData::CapCellEntityId(vtkIdType boundaryIndex, vtk
       && this->BoundaryCellEntityIds->GetValue(boundaryId) >= 0)
     {
     return this->BoundaryCellEntityIds->GetValue(boundaryId);
+    }
+  if (useBoundaryLabels)
+    {
+    // The boundary's label is its name, and so the cap's id; neither it nor a chosen id is
+    // shifted by CellEntityIdOffset.
+    return boundaryId;
     }
   return boundaryIndex+1+this->CellEntityIdOffset;
 }

--- a/vtkVmtk/Misc/vtkvmtkSmoothCapPolyData.h
+++ b/vtkVmtk/Misc/vtkvmtkSmoothCapPolyData.h
@@ -113,8 +113,9 @@ class VTK_VMTK_MISC_EXPORT vtkvmtkSmoothCapPolyData : public vtkPolyDataAlgorith
    * the way boundary ids are indexed everywhere else here (see BoundaryIds): entry i is the id
    * given to the cap closing the boundary whose id is i.
    *
-   * An id beyond the end of the array, or one whose entry is negative, keeps the id the
-   * boundary's position would have given it. An id chosen here is used as it stands, with
+   * An id beyond the end of the array, or one whose entry is negative, is no entry at all: with
+   * the labels in use that cap keeps its boundary's label, and without them the id its position
+   * would have given it. An id chosen here is used as it stands, with
    * CellEntityIdOffset not added to it, while the offset still lands on the cells copied from
    * the input and on any boundary left to its positional id.
    */
@@ -155,7 +156,7 @@ class VTK_VMTK_MISC_EXPORT vtkvmtkSmoothCapPolyData : public vtkPolyDataAlgorith
 
   /// The id to tag the cap of a boundary with: the one BoundaryCellEntityIds chose for it, or
   /// the one its position gives it.
-  vtkIdType CapCellEntityId(vtkIdType boundaryIndex, vtkIdType boundaryId);
+  vtkIdType CapCellEntityId(vtkIdType boundaryIndex, vtkIdType boundaryId, bool useBoundaryLabels);
 
   vtkIdList* BoundaryIds;
   char* BoundaryLabelsArrayName;


### PR DESCRIPTION
The labels named a boundary but never named its cap: with the labels in use and no BoundaryCellEntityIds, a cap still took the id its boundary's position in the extraction order gave it, so a caller that had gone to the trouble of labelling its surface had to supply a second array mapping each label to the id it wanted. Labelling a boundary 5 and capping it produced a cap numbered 1.

With the labels in use, take the boundary's label as its cap's id unless BoundaryCellEntityIds names another. A label is as deliberate as an entry in that array, so CellEntityIdOffset shifts neither; the offset still lands on the cells copied from the input and on the ids derived for a boundary with no label. A caller that wants the two to differ still says so, and one that does not can now label a boundary with the id it wants and pass no array at all. In the annular cappers, where a cap closes a pair, the unchosen id is the pair's lower label, the same rule that settles a disagreement between the two -- so a surface labelled in the labeller's annular mode names each cap after its inner boundary with nothing else asked for.

Without the labels nothing changes: the caps are numbered by position, as they always were.