### PR TITLE
Close a smooth cap with triangles rather than cells that may not triangulate

### DIFF
--- a/tests/test_vmtkScripts/test_vmtkcappers.py
+++ b/tests/test_vmtkScripts/test_vmtkcappers.py
@@ -176,6 +176,47 @@ def test_cap_ids_are_positional_when_the_labels_are_not_used(capperClass):
     assert ids == [0, 1, 2]
 
 
+def test_the_smooth_cap_is_made_of_triangles():
+    """Whatever the ring geometry comes out as, the cells are triangles.
+
+    The rings used to be closed with quadrilaterals, and the warp that places a ring can bring
+    neighbouring points of it past each other, so that the quad through them crosses itself.
+    vtkTriangleFilter gives up on such a cell and emits nothing for it, which takes a hole out of
+    a cap that was closed -- and a caller triangulating the output, as the doc string tells it to,
+    got back an open surface. Splitting the ring cells here means there is nothing left to fail
+    on.
+    """
+    surface, _labels = labelled(tube_surface())
+
+    capper = vtkvmtk.vtkvmtkSmoothCapPolyData()
+    capper.SetInputData(surface)
+    capper.SetConstraintFactor(0.0)
+    capper.SetNumberOfRings(8)
+    capper.Update()
+    capped = capper.GetOutput()
+
+    assert capped.GetNumberOfCells() > 0
+    assert capped.GetPolys().IsHomogeneous() == 3
+
+    # and triangulating it, which is what a caller does, leaves it as it was and still closed
+    triangles = vtk.vtkTriangleFilter()
+    triangles.SetInputData(capped)
+    triangles.PassLinesOff()
+    triangles.PassVertsOff()
+    triangles.Update()
+    assert triangles.GetOutput().GetNumberOfCells() == capped.GetNumberOfCells()
+
+    for polyData in (capped, triangles.GetOutput()):
+        featureEdges = vtk.vtkFeatureEdges()
+        featureEdges.SetInputData(polyData)
+        featureEdges.BoundaryEdgesOn()
+        featureEdges.FeatureEdgesOff()
+        featureEdges.NonManifoldEdgesOff()
+        featureEdges.ManifoldEdgesOff()
+        featureEdges.Update()
+        assert featureEdges.GetOutput().GetNumberOfCells() == 0
+
+
 @pytest.mark.parametrize('capperClass', ANNULAR_CAPPERS)
 def test_annular_cap_takes_the_id_of_the_inner_boundary(capperClass):
     """A cap here closes a pair, so it has two labels to choose between. Labelled in annular mode

--- a/vtkVmtk/Misc/vtkvmtkSmoothCapPolyData.cxx
+++ b/vtkVmtk/Misc/vtkvmtkSmoothCapPolyData.cxx
@@ -258,25 +258,60 @@ int vtkvmtkSmoothCapPolyData::RequestData(
         }
       for (i=0; i<numberOfBoundaryPoints; i++)
         {
-        vtkIdList* newPolyIds = vtkIdList::New();
-        newPolyIds->InsertNextId(previousCirclePointIds->GetId(i));
-        newPolyIds->InsertNextId(previousCirclePointIds->GetId((i+1)%numberOfBoundaryPoints));
-        newPolyIds->InsertNextId(circlePointIds->GetId((i+1)%numberOfBoundaryPoints));
-        newPolyIds->InsertNextId(circlePointIds->GetId(i));
-        newPolys->InsertNextCell(newPolyIds);
-        newPolyIds->Delete();
+        // Two triangles rather than the quad they would make. The four points are not reliably
+        // a simple quadrilateral: the warp that places a ring can bring neighbouring points of
+        // it past each other, and the quad through them then crosses itself. vtkTriangleFilter
+        // gives up on such a cell and emits nothing for it, which takes a hole out of a cap that
+        // was closed - so the split is made here, where the two triangles are known, instead of
+        // being left to a filter that cannot always make it.
+        vtkIdType previousId = previousCirclePointIds->GetId(i);
+        vtkIdType previousNextId = previousCirclePointIds->GetId((i+1)%numberOfBoundaryPoints);
+        vtkIdType currentId = circlePointIds->GetId(i);
+        vtkIdType currentNextId = circlePointIds->GetId((i+1)%numberOfBoundaryPoints);
+
+        vtkIdType firstTriangle[3] = {previousId, previousNextId, currentId};
+        vtkIdType secondTriangle[3] = {previousNextId, currentNextId, currentId};
+        newPolys->InsertNextCell(3,firstTriangle);
+        newPolys->InsertNextCell(3,secondTriangle);
         if (markCells)
           {
-          cellEntityIdsArray->InsertNextValue(this->CapCellEntityId(boundaryId,capBoundaryId,useBoundaryLabels));
+          vtkIdType capCellEntityId = this->CapCellEntityId(boundaryId,capBoundaryId,useBoundaryLabels);
+          cellEntityIdsArray->InsertNextValue(capCellEntityId);
+          cellEntityIdsArray->InsertNextValue(capCellEntityId);
           }
         }
       }
 
-    newPolys->InsertNextCell(circlePointIds);
-
-    if (markCells)
+    // The innermost ring closes the cap. It used to be one polygon, which leaves the same trap
+    // as the ring cells did: the ring is not reliably convex, or even simple, so a filter asked
+    // to triangulate it can fail and leave the tip open. Close it with a fan from its own centre
+    // instead, which is a triangle either way.
+    double tipCentre[3] = {0.0, 0.0, 0.0};
+    vtkIdType numberOfTipPoints = circlePointIds->GetNumberOfIds();
+    for (i=0; i<numberOfTipPoints; i++)
       {
-      cellEntityIdsArray->InsertNextValue(this->CapCellEntityId(boundaryId,capBoundaryId,useBoundaryLabels));
+      double tipPoint[3];
+      newPoints->GetPoint(circlePointIds->GetId(i),tipPoint);
+      for (int component=0; component<3; component++)
+        {
+        tipCentre[component] += tipPoint[component];
+        }
+      }
+    for (int component=0; component<3; component++)
+      {
+      tipCentre[component] /= static_cast<double>(numberOfTipPoints);
+      }
+    vtkIdType tipCentreId = newPoints->InsertNextPoint(tipCentre);
+    for (i=0; i<numberOfTipPoints; i++)
+      {
+      vtkIdType tipTriangle[3] = {circlePointIds->GetId(i),
+                                  circlePointIds->GetId((i+1)%numberOfTipPoints),
+                                  tipCentreId};
+      newPolys->InsertNextCell(3,tipTriangle);
+      if (markCells)
+        {
+        cellEntityIdsArray->InsertNextValue(this->CapCellEntityId(boundaryId,capBoundaryId,useBoundaryLabels));
+        }
       }
 
     boundaryPointIds->Delete();


### PR DESCRIPTION
vtkvmtkSmoothCapPolyData built its cap out of quadrilaterals between consecutive rings, and closed the middle with one polygon through the innermost ring. Neither is reliably a simple, convex cell: the thin plate spline that places a ring can bring neighbouring points of it past each other, and the quad through them then crosses itself. vtkTriangleFilter gives up on such a cell and emits nothing for it, so a caller triangulating the output - which the class documentation tells it to do, the cells not being triangles - got back a cap with a hole in it. On a clipped aorta two quads of one cap crossed, and triangulating the capped surface opened a six edge hole in it while reporting nothing.

Split each ring cell into the two triangles it is made of, and close the tip with a fan from the centre of the innermost ring, so that every cell the filter emits is a triangle and there is nothing left for a caller to triangulate. The points are unchanged apart from the one added at the centre of each tip, so the cap has the shape it had.