### PR TITLE
Fix volumetric mesh generation on Windows

### DIFF
--- a/vtkVmtk/ComputationalGeometry/vtkvmtkAppendFilter.cxx
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkAppendFilter.cxx
@@ -271,6 +271,7 @@ int vtkvmtkAppendFilter::RequestData(
   newPts->Delete();
   ptIds->Delete();
   newPtIds->Delete();
+  ptIdMap->Delete();
   locator->Delete();
 
   return 1;

--- a/vtkVmtk/Misc/vtkvmtkBoundaryLayerGenerator.cxx
+++ b/vtkVmtk/Misc/vtkvmtkBoundaryLayerGenerator.cxx
@@ -944,6 +944,8 @@ void vtkvmtkBoundaryLayerGenerator::IncrementalWarpPoints(vtkUnstructuredGrid* i
 
   cellIds->Delete();
   neighborIds->Delete();
+  edgePointIds->Delete();
+  edgeNeighborCellIds->Delete();
 }
 
 void vtkvmtkBoundaryLayerGenerator::PrintSelf(std::ostream& os, vtkIndent indent)

--- a/vtkVmtk/Misc/vtkvmtkTetGenWrapper.cxx
+++ b/vtkVmtk/Misc/vtkvmtkTetGenWrapper.cxx
@@ -220,7 +220,28 @@ int vtkvmtkTetGenWrapper::RequestData(
 
   if (this->UseSizingFunction && sizingFunctionArray)
     {
-    tetgenOptionString += "m"; 
+    // TetGen reads a sizing function through its -m switch, and -m means "take the sizes from a
+    // background mesh". This wrapper has no way to hand one over, so TetGen makes its own by
+    // duplicating the mesh it is about to refine, and that path does not answer the same way
+    // twice: the same surface, meshed twice over in one session, comes back filled with
+    // tetrahedra one time and empty the next. Nothing is produced here rather than a mesh that
+    // cannot be reproduced.
+    vtkErrorMacro(<<"UseSizingFunction is on, and the sizing function array '"
+      <<this->SizingFunctionArrayName<<"' was found on the input, so TetGen would be run with its "
+      "-m switch. -m takes element sizes from a background mesh; with none given, TetGen builds "
+      "one out of the mesh it is meshing, and that gives a different answer from one run to the "
+      "next - the same input meshed twice in one session comes back tetrahedralized once and "
+      "empty once. No mesh is generated, rather than one that cannot be reproduced.\n"
+      "  To ask for a size without it: leave UseSizingFunction off and bound the element volume "
+      "instead, with SetFixedVolume(1) and SetMaxVolume(v), where v is the volume of the regular "
+      "tetrahedron of the edge length wanted - v = a*a*a/(6*sqrt(2)) for edge length a. That "
+      "gives the same mesh every time.\n"
+      "  A single volume bound is one size for the whole mesh, where the sizing function was a "
+      "size per point. Where the size has to vary, vary the triangles of the surface that is "
+      "handed in: the elements against it follow their size, and the bound then only says how "
+      "coarse the middle may become.");
+    this->SetLastRunExitStatus(1);
+    return 1;
     }
 
   tetgenio in_tetgenio;

--- a/vtkVmtk/Misc/vtkvmtkTetGenWrapper.h
+++ b/vtkVmtk/Misc/vtkvmtkTetGenWrapper.h
@@ -290,6 +290,12 @@ class VTK_VMTK_MISC_EXPORT vtkvmtkTetGenWrapper : public vtkUnstructuredGridAlgo
    * Toggle using the per-point sizing function (SizingFunctionArrayName) as a spatially-varying
    * maximum tetrahedron volume constraint (TetGen "-m" switch, used together with VarVolume).
    * Default: off.
+   *
+   * Turning this on is refused, with an error saying what to do instead: "-m" takes its sizes
+   * from a background mesh, this wrapper cannot supply one, and the mesh TetGen then builds for
+   * itself puts it on a path that does not answer the same way twice - the same input meshed
+   * twice in one session comes back tetrahedralized once and empty once. Bound the element
+   * volume with FixedVolume and MaxVolume instead.
    */
   vtkSetMacro(UseSizingFunction,int);
   vtkGetMacro(UseSizingFunction,int);

--- a/vtkVmtk/Utilities/tetgen1.4.3/tetgen.cxx
+++ b/vtkVmtk/Utilities/tetgen1.4.3/tetgen.cxx
@@ -4825,16 +4825,16 @@ void tetgenmesh::maketetrahedronmap(int*& idx2tetlist,
 
 void tetgenmesh::dummyinit(int tetwords, int shwords)
 {
-  unsigned long alignptr;
+  uintptr_t alignptr;
 
   // Set up 'dummytet', the 'tetrahedron' that occupies "outer space".
   dummytetbase = (tetrahedron *) new char[tetwords * sizeof(tetrahedron)
                                           + tetrahedrons->alignbytes];
   // Align 'dummytet' on a 'tetrahedrons->alignbytes'-byte boundary.
-  alignptr = (unsigned long) dummytetbase;
+  alignptr = (uintptr_t) dummytetbase;
   dummytet = (tetrahedron *)
-    (alignptr + (unsigned long) tetrahedrons->alignbytes
-     - (alignptr % (unsigned long) tetrahedrons->alignbytes));
+    (alignptr + (uintptr_t) tetrahedrons->alignbytes
+     - (alignptr % (uintptr_t) tetrahedrons->alignbytes));
   // Initialize the four adjoining tetrahedra to be "outer space". These
   //   will eventually be changed by various bonding operations, but their
   //   values don't really matter, as long as they can legally be
@@ -4856,10 +4856,10 @@ void tetgenmesh::dummyinit(int tetwords, int shwords)
     dummyshbase = (shellface *) new char[shwords * sizeof(shellface)
                                          + subfaces->alignbytes];
     // Align 'dummysh' on a 'subfaces->alignbytes'-byte boundary.
-    alignptr = (unsigned long) dummyshbase;
+    alignptr = (uintptr_t) dummyshbase;
     dummysh = (shellface *)
-      (alignptr + (unsigned long) subfaces->alignbytes
-       - (alignptr % (unsigned long) subfaces->alignbytes));
+      (alignptr + (uintptr_t) subfaces->alignbytes
+       - (alignptr % (uintptr_t) subfaces->alignbytes));
     // Initialize the three adjoining subfaces to be the omnipresent
     //   subface. These will eventually be changed by various bonding
     //   operations, but their values don't really matter, as long as they
@@ -8313,7 +8313,7 @@ void tetgenmesh::randomsample(point searchpt, triface *searchtet)
   void **sampleblock;
   long sampleblocks, samplesperblock, samplenum;
   long tetblocks, i, j;
-  unsigned long alignptr;
+  uintptr_t alignptr;
   REAL searchdist, dist;
 
   // 'searchtet' should be a valid tetrahedron.
@@ -8359,10 +8359,10 @@ void tetgenmesh::randomsample(point searchpt, triface *searchtet)
   sampleblocks = samples / samplesperblock;
   sampleblock = tetrahedrons->firstblock;
   for (i = 0; i < sampleblocks; i++) {
-    alignptr = (unsigned long) (sampleblock + 1);
+    alignptr = (uintptr_t) (sampleblock + 1);
     firsttet = (tetrahedron *)
-               (alignptr + (unsigned long) tetrahedrons->alignbytes
-               - (alignptr % (unsigned long) tetrahedrons->alignbytes));
+               (alignptr + (uintptr_t) tetrahedrons->alignbytes
+               - (alignptr % (uintptr_t) tetrahedrons->alignbytes));
     for (j = 0; j < samplesperblock; j++) {
       if (i == tetblocks - 1) {
         // This is the last block.

--- a/vtkVmtk/Utilities/tetgen1.4.3/tetgen.h
+++ b/vtkVmtk/Utilities/tetgen1.4.3/tetgen.h
@@ -3300,7 +3300,7 @@ inline bool tetgenmesh::isfacehasedge(face* s, point tend1, point tend2) {
 
 inline bool tetgenmesh::issymexist(triface* t) {
   tetrahedron *ptr = (tetrahedron *) 
-    ((unsigned long)(t->tet[t->loc]) & ~(unsigned long)7l);
+    ((uintptr_t)(t->tet[t->loc]) & ~(uintptr_t)7l);
   return ptr != dummytet;
 }
 


### PR DESCRIPTION
Four fixes found while building a CFD meshing module on top of `vmtkmeshgenerator`.

**TetGen crashed on any input on Win64.** It aligns `dummytet`, `dummysh` and its
point-sampling blocks by casting pointers through `unsigned long`, which is 64 bits
on Linux and macOS and 32 bits on Win64, so those pointers came back truncated to
their low half. The result is an access violation inside `tetrahedralize()` on any
input at all — a four-point PLC describing a single tetrahedron is enough. Nothing
that reaches TetGen has ever worked in a Windows build, `vmtktetgen` and
`vmtkmeshgenerator` included. The casts now go through `uintptr_t`, which
`tetgen.h` already typedefs for this compiler.

**Two leaks.** `IncrementalWarpPoints` allocates four `vtkIdList`s and frees two, so
a boundary layer leaks two per substep taken. `vtkvmtkAppendFilter::RequestData`
leaks its `ptIdMap` once per run.

**`UseSizingFunction` gave a different mesh each run.** It asks for TetGen's `-m`,
which takes sizes from a background mesh; with none given, TetGen builds one by
duplicating the mesh it is refining, and that path is not repeatable — the same
surface meshed twice in one session came back with 39818 tetrahedra one time and
empty the next, deterministically alternating. It is now refused with an error
saying so and pointing at `FixedVolume`/`MaxVolume` instead. On a clipped aorta
remeshed at 2 mm, a volume bound taken from that edge length gave a slightly finer
mesh than the sizing function had asked for (44345 tets vs 39818), a tighter spread
of sizes and a better worst-case radius-edge ratio.

Verified on Windows (Slicer 5.13 / VTK 9.4, MSVC 2022): TetGen meshes a single
tetrahedron and a clipped aorta; a boundary-layer run reports no leaked objects;
and the refusal fires with the remedy it names producing a mesh.
