### PR TITLE
Fixes in boundary labeling and capping

### DIFF
--- a/tests/test_vmtkScripts/test_vmtkboundarylabeler.py
+++ b/tests/test_vmtkScripts/test_vmtkboundarylabeler.py
@@ -85,13 +85,23 @@ def test_boundary_extraction_order_labels_every_boundary(tube):
     labeler = label(tube)
 
     assert labeler.NumberOfBoundaries == 2
-    assert labeler.BoundaryLabels == [0, 1]
+    # a label is the cell entity id of the cap that will close its boundary, so the labels start
+    # above the wall (entityidoffset, 1 by default) rather than at zero
+    assert labeler.BoundaryLabels == [2, 3]
     assert labeler.UnmatchedPlaneLabels == []
 
     labels, rings = labels_of_boundaries(labeler.Surface)
-    assert labels == [0, 1]
+    assert labels == [2, 3]
     # every point of each boundary is accounted for, and no interior point is claimed
     assert sorted(len(ring) for ring in rings) == [24, 24]
+
+
+def test_boundary_extraction_order_follows_the_entity_id_offset(tube):
+    """The labels are the ids the capper would have given the caps itself, so moving the wall
+    moves them with it."""
+    labeler = label(tube, CellEntityIdOffset=10)
+
+    assert labeler.BoundaryLabels == [11, 12]
 
 
 def test_extractor_lists_each_boundary_point_once(tube):
@@ -390,7 +400,7 @@ def test_annular_is_off_by_default():
 
     assert labeler.GetAnnular() is False
     assert labeler.GetAnnularOuterBoundaryOffset() == OUTER_OFFSET
-    assert sorted(labeler.GetBoundaryLabels().GetId(i) for i in range(4)) == [0, 1, 2, 3]
+    assert sorted(labeler.GetBoundaryLabels().GetId(i) for i in range(4)) == [2, 3, 4, 5]
 
 
 def test_annular_names_each_outer_boundary_after_its_inner_partner():

--- a/tests/test_vmtkScripts/test_vmtkcappers.py
+++ b/tests/test_vmtkScripts/test_vmtkcappers.py
@@ -36,6 +36,10 @@ except ImportError:
 LABELS = 'BoundaryLabels'
 ORDER = 'BoundaryPointOrder'
 CELL_ENTITY_IDS = 'CellEntityIds'
+# The wall id these tests cap with, and the one they label with: the two have to be the same
+# number for a label to be the id of the cap that closes its boundary. Not the default 1, so
+# that nothing here passes by accident of the default.
+CELL_ENTITY_ID_OFFSET = 0
 OUTER_OFFSET = 1000
 
 TUBE_LENGTH = 6.0
@@ -75,10 +79,15 @@ def walled_tube_surface():
     return walled.GetOutput()
 
 
-def labelled(surface, annular=False):
-    """surface with the boundary label arrays written on it, and the labels themselves."""
+def labelled(surface, annular=False, cellEntityIdOffset=CELL_ENTITY_ID_OFFSET):
+    """surface with the boundary label arrays written on it, and the labels themselves.
+
+    Labelled with the offset the cappers here are given, which is what the two have to agree on:
+    a label is the id of the cap that will close its boundary, so it has to be numbered above the
+    same wall the capper leaves on the cells it copies."""
     labeler = vtkvmtk.vtkvmtkPolyDataBoundaryLabeler()
     labeler.SetInputData(surface)
+    labeler.SetCellEntityIdOffset(cellEntityIdOffset)
     labeler.SetAnnular(annular)
     labeler.Update()
     labels = [labeler.GetBoundaryLabels().GetId(i) for i in range(labeler.GetNumberOfBoundaries())]
@@ -101,7 +110,7 @@ def cap_ids(capper, surface, useLabels=False, boundaryCellEntityIds=None):
     """The distinct cell entity ids of the capped surface."""
     capper.SetInputData(surface)
     capper.SetCellEntityIdsArrayName(CELL_ENTITY_IDS)
-    capper.SetCellEntityIdOffset(0)
+    capper.SetCellEntityIdOffset(CELL_ENTITY_ID_OFFSET)
     if useLabels:
         capper.SetBoundaryLabelsArrayName(LABELS)
         capper.SetBoundaryPointOrderArrayName(ORDER)
@@ -135,8 +144,8 @@ def test_cap_takes_the_id_chosen_for_the_boundary_it_closes(capperClass):
     ids = cap_ids(capperClass(), surface, useLabels=True,
                   boundaryCellEntityIds=chosen_ids(wanted))
 
-    # 0 is the wall, which keeps the offset; each cap carries the id asked for by label
-    assert ids == sorted(set([0]) | set(wanted.values()))
+    # the wall keeps the offset; each cap carries the id asked for by label
+    assert ids == sorted(set([CELL_ENTITY_ID_OFFSET]) | set(wanted.values()))
 
 
 @pytest.mark.parametrize('capperClass', SINGLE_BOUNDARY_CAPPERS)
@@ -147,9 +156,10 @@ def test_cap_takes_the_boundary_label_when_no_id_is_chosen(capperClass):
 
     ids = cap_ids(capperClass(), surface, useLabels=True)
 
-    # 0 is the wall here as well as the label of the first boundary, so both caps are accounted
-    # for by their labels
-    assert ids == sorted(set([0]) | set(labels))
+    # the wall keeps the offset and the caps carry their labels, which are numbered above it, so
+    # no cap can be mistaken for the wall
+    assert CELL_ENTITY_ID_OFFSET not in labels
+    assert ids == sorted([CELL_ENTITY_ID_OFFSET] + list(labels))
 
 
 @pytest.mark.parametrize('capperClass', SINGLE_BOUNDARY_CAPPERS)
@@ -173,7 +183,21 @@ def test_cap_ids_are_positional_when_the_labels_are_not_used(capperClass):
     arrays named, the caps are numbered by the order the boundaries come out in."""
     ids = cap_ids(capperClass(), tube_surface())
 
-    assert ids == [0, 1, 2]
+    assert ids == [CELL_ENTITY_ID_OFFSET, CELL_ENTITY_ID_OFFSET + 1, CELL_ENTITY_ID_OFFSET + 2]
+
+
+@pytest.mark.parametrize('capperClass', SINGLE_BOUNDARY_CAPPERS)
+def test_labelling_a_surface_does_not_change_how_it_is_capped(capperClass):
+    """The labeler numbers a boundary with the id the capper would have given its cap anyway, so
+    labelling a surface and capping it comes out cell entity id for cell entity id the same as
+    capping it unlabelled. That is what lets the labels be turned on for a pipeline that had them
+    off without renumbering the boundary conditions of everything downstream."""
+    surface, labels = labelled(tube_surface())
+
+    assert cap_ids(capperClass(), surface, useLabels=True) == cap_ids(capperClass(), tube_surface())
+    # and the labels themselves are those ids, so a vessel end is the same number in the point
+    # data that says which end it is and in the cell data a solver reads its faces from
+    assert sorted(labels) == [CELL_ENTITY_ID_OFFSET + 1, CELL_ENTITY_ID_OFFSET + 2]
 
 
 def test_the_smooth_cap_is_made_of_triangles():
@@ -228,7 +252,7 @@ def test_annular_cap_takes_the_id_of_the_inner_boundary(capperClass):
     ids = cap_ids(capperClass(), surface, useLabels=True,
                   boundaryCellEntityIds=chosen_ids(wanted))
 
-    assert ids == sorted(set([0]) | set(wanted.values()))
+    assert ids == sorted(set([CELL_ENTITY_ID_OFFSET]) | set(wanted.values()))
 
 
 @pytest.mark.parametrize('capperClass', ANNULAR_CAPPERS)
@@ -244,11 +268,11 @@ def test_annular_cap_prefers_the_lower_boundary_id_when_both_are_named(capperCla
                   boundaryCellEntityIds=chosen_ids(wanted))
 
     innerIds = [700 + label for label in labels if label < OUTER_OFFSET]
-    assert ids == sorted(set([0]) | set(innerIds))
+    assert ids == sorted(set([CELL_ENTITY_ID_OFFSET]) | set(innerIds))
 
 
 @pytest.mark.parametrize('capperClass', ANNULAR_CAPPERS)
 def test_annular_cap_ids_are_positional_when_the_labels_are_not_used(capperClass):
     ids = cap_ids(capperClass(), walled_tube_surface())
 
-    assert ids == [0, 1, 2]
+    assert ids == [CELL_ENTITY_ID_OFFSET, CELL_ENTITY_ID_OFFSET + 1, CELL_ENTITY_ID_OFFSET + 2]

--- a/vmtkScripts/vmtkboundarylabeler.py
+++ b/vmtkScripts/vmtkboundarylabeler.py
@@ -30,6 +30,7 @@ class vmtkBoundaryLabeler(pypes.pypeScript):
         self.BoundaryLabelsArrayName = 'BoundaryLabels'
         self.BoundaryPointOrderArrayName = 'BoundaryPointOrder'
         self.LabelingMode = 'boundaryextractionorder'
+        self.CellEntityIdOffset = 1
         self.PlaneOrigins = None
         self.PlaneNormals = None
         self.PlaneLabels = None
@@ -46,10 +47,11 @@ class vmtkBoundaryLabeler(pypes.pypeScript):
             ['Surface','i','vtkPolyData',1,'','the input surface','vmtksurfacereader'],
             ['BoundaryLabelsArrayName','boundarylabelsarray','str',1,'','name of the point data array where each boundary point\'s label has to be stored'],
             ['BoundaryPointOrderArrayName','boundarypointorderarray','str',1,'','name of the point data array where the position of each point within its own boundary has to be stored'],
-            ['LabelingMode','labelingmode','str',1,'["boundaryextractionorder","closesttoplaneorigin","onplane","matchexistinglabels"]','where the labels come from: boundaryextractionorder gives boundary i the label i, i being its position in the order the boundary extraction returns the boundaries in; closesttoplaneorigin gives each plane\'s label to the boundary lying nearest its origin, the normal not being used; onplane gives a boundary a plane\'s label when every one of its points lies in that plane within maxdistancefromplane; matchexistinglabels gives a boundary the label a strict majority of its own points already carry, which is how a surface is brought back into line after a filter that knew nothing about the arrays; it matches labels rather than geometry, so a newly cut boundary gets a fresh label rather than the label of the nearest old one'],
+            ['LabelingMode','labelingmode','str',1,'["boundaryextractionorder","closesttoplaneorigin","onplane","matchexistinglabels"]','where the labels come from: boundaryextractionorder gives boundary i the label i+1+entityidoffset, i being its position in the order the boundary extraction returns the boundaries in, which is the id vmtksurfacecapper would have given its cap anyway; closesttoplaneorigin gives each plane\'s label to the boundary lying nearest its origin, the normal not being used; onplane gives a boundary a plane\'s label when every one of its points lies in that plane within maxdistancefromplane; matchexistinglabels gives a boundary the label a strict majority of its own points already carry, which is how a surface is brought back into line after a filter that knew nothing about the arrays; it matches labels rather than geometry, so a newly cut boundary gets a fresh label rather than the label of the nearest old one'],
+            ['CellEntityIdOffset','entityidoffset','int',1,'','cell entity id of the wall, which the labels are numbered above; a label is the cell entity id of the cap that will close its boundary, and a capper leaves this value on the cells it copied from its input, so the first id a cap may take is the one above it; leave it at the entityidoffset vmtksurfacecapper will be run with'],
             ['PlaneOrigins','planeorigins','float',-1,'','plane origins, three coordinates per plane; a point is a plane whose normal is never asked for, so this is also where positions go when there are no planes to give'],
             ['PlaneNormals','planenormals','float',-1,'','plane normals, three components per plane; required by the onplane mode and ignored by the others'],
-            ['PlaneLabels','planelabels','int',-1,'','label to give the boundary each plane matches; plane i is taken to carry the label i when this is not given'],
+            ['PlaneLabels','planelabels','int',-1,'','label to give the boundary each plane matches; plane i is taken to carry the label i+1+entityidoffset when this is not given; a label given here is used as it stands, so keeping it above entityidoffset is up to the caller'],
             ['MaximumDistanceFromPlane','maxdistancefromplane','float',1,'(0.0,)','how far any point of a boundary may be from a plane for that boundary to count as lying in it; used by the onplane mode, which requires a positive value, a plane being infinite and every boundary lying in it otherwise'],
             ['MaximumDistanceFromPlaneOrigin','maxdistancefromplaneorigin','float',1,'(0.0,)','how far any point of a boundary may be from a plane origin for that boundary to be a candidate for that plane label; a boundary is considered only when it lies entirely within this distance, so one point of it beyond and it is passed over however well the rest fits; zero puts no limit on it; used by both the closesttoplaneorigin and the onplane modes']
             ])
@@ -79,6 +81,7 @@ class vmtkBoundaryLabeler(pypes.pypeScript):
         labeler.SetInputData(self.Surface)
         labeler.SetBoundaryLabelsArrayName(self.BoundaryLabelsArrayName)
         labeler.SetBoundaryPointOrderArrayName(self.BoundaryPointOrderArrayName)
+        labeler.SetCellEntityIdOffset(self.CellEntityIdOffset)
         labeler.SetMaximumDistanceFromPlane(self.MaximumDistanceFromPlane)
         labeler.SetMaximumDistanceFromPlaneOrigin(self.MaximumDistanceFromPlaneOrigin)
 

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkBoundaryLabels.cxx
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkBoundaryLabels.cxx
@@ -123,6 +123,15 @@ bool vtkvmtkBoundaryLabels::GetBoundaries(vtkPolyData* surface, const char* boun
     return true;
     }
 
+  // Cell links, to tell an edge that still has only one cell behind it from one that has been
+  // closed since. Built on a copy of the structure rather than on surface itself: BuildLinks on
+  // the caller's own polydata leaves it holding a reference it did not ask for.
+  vtkNew<vtkPolyData> working;
+  working->CopyStructure(surface);
+  working->BuildLinks();
+  vtkNew<vtkIdList> edgeNeighbors;
+
+  std::vector<vtkIdType> closedLabels;
   for (std::map<vtkIdType,std::vector<std::pair<vtkIdType,vtkIdType> > >::iterator
        boundary=pointsByLabel.begin(); boundary!=pointsByLabel.end(); ++boundary)
     {
@@ -143,6 +152,32 @@ bool vtkvmtkBoundaryLabels::GetBoundaries(vtkPolyData* surface, const char* boun
         return false;
         }
       }
+    // A ring the arrays describe is not necessarily still an open boundary. The labels are left
+    // on the points of a boundary that has been capped, on purpose, as a record of which vessel
+    // end that ring was -- so a surface that has been through a capper carries rings with cells
+    // on both sides of them. Handing one of those back as a boundary has it capped a second
+    // time, over the cap already there, which is not an error anywhere it would be noticed: the
+    // surface comes back closed, of very nearly the right size, and non-manifold along every rim.
+    // What the extractor would return is the test, and it returns open boundaries only.
+    size_t numberOfRingPoints = ring.size();
+    bool stillOpen = true;
+    for (size_t index=0; index<numberOfRingPoints && stillOpen; index++)
+      {
+      working->GetCellEdgeNeighbors(-1,ring[index].second,
+                                    ring[(index+1)%numberOfRingPoints].second,edgeNeighbors);
+      // One cell behind the edge and it is on the boundary of the surface; two and it is inside
+      // it. Zero means the two points are no longer joined by an edge at all, which is no more
+      // an open boundary than the others.
+      stillOpen = (edgeNeighbors->GetNumberOfIds() == 1);
+      }
+    if (!stillOpen)
+      {
+      closedLabels.push_back(boundary->first);
+      }
+    }
+  for (size_t index=0; index<closedLabels.size(); index++)
+    {
+    pointsByLabel.erase(closedLabels[index]);
     }
 
   // Each point of a boundary is listed once, the way vtkvmtkPolyDataBoundaryExtractor lists

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkBoundaryLabels.h
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkBoundaryLabels.h
@@ -130,6 +130,13 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkBoundaryLabels : public vtkO
    * mesh, a merge that collapsed two points of a ring onto one, and the fractional values a
    * clipping filter leaves behind when it interpolates the arrays onto the points it creates.
    * A boundary whose points were all removed simply disappears, which is not an error.
+   *
+   * Nor is a boundary that is no longer open. The labels stay on the points of a boundary that
+   * has been capped, on purpose, as a record of which vessel end that ring was, so a surface
+   * that has been through a capper carries rings with cells on both sides of them. Only rings
+   * every edge of which still has a single cell behind it are returned, which is what the
+   * extractor would have found; a surface every boundary of which has been closed comes back
+   * with none, the same answer as for a surface that never had any.
    */
   static bool GetBoundaries(vtkPolyData* surface, const char* boundaryLabelsArrayName, const char* boundaryPointOrderArrayName, vtkPolyData* boundaries, vtkIdList* boundaryLabels);
 

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkBoundaryLabels.h
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkBoundaryLabels.h
@@ -30,7 +30,13 @@ Program:   VMTK
  * answer travels with the mesh:
  *
  * - the labels array holds, on each point of a boundary, the label of the boundary it belongs
- *   to, and InvalidBoundaryLabel on every other point. This is the boundary's identity.
+ *   to, and InvalidBoundaryLabel on every other point. This is the boundary's identity, and it
+ *   is also the cell entity id of the cap that closes that boundary: the cappers here read a
+ *   label as the id to give the cap they build, so the one number names the vessel end in the
+ *   point data and names its face in the cell data. Labels therefore start above the wall
+ *   rather than at zero -- vtkvmtkPolyDataBoundaryLabeler::CellEntityIdOffset is where that is
+ *   decided. InvalidBoundaryLabel is negative and so is no cell entity id at all: it says the
+ *   point is on no boundary, not that it belongs to any particular face.
  * - the point order array holds that point's index within its boundary, 0..n-1, and
  *   InvalidBoundaryLabel elsewhere. This is the ring's order and its winding direction.
  *

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkCapPolyData.h
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkCapPolyData.h
@@ -95,7 +95,12 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkCapPolyData : public vtkPoly
       labels in use a boundary's id is its label, and without them it is the boundary's position
       in the order the extractor returns, which is what it has always been. So BoundaryIds and
       BoundaryCellEntityIds are read the same way either way, and a caller that labels its surface
-      gets ids that survive the filters in between without having to say so twice. */
+      gets ids that survive the filters in between without having to say so twice.
+
+      A label is not merely a name this filter then has to turn into an id: it is the id. The
+      labeler numbers the boundaries of a surface from CellEntityIdOffset+1 up, which is where
+      this filter would have numbered their caps anyway, so the cap of a labeled boundary carries
+      its label unchanged and a labeled surface is capped exactly as an unlabeled one is. */
   vtkSetStringMacro(BoundaryLabelsArrayName);
   vtkGetStringMacro(BoundaryLabelsArrayName);
   vtkSetStringMacro(BoundaryPointOrderArrayName);
@@ -108,12 +113,13 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkCapPolyData : public vtkPoly
       given to the cap closing the boundary whose id is i.
 
       An id beyond the end of the array, or one whose entry is negative, is no entry at all: with
-      the labels in use that cap keeps its boundary's label, which names it just as well, and
-      without them the id its position would have given it. An output can carry ids from both
-      rules at once.
+      the labels in use that cap keeps its boundary's label, which already is the id its position
+      would have given it, and without them the id its position gives it. An output can carry ids
+      from both rules at once.
       An id chosen here is used as it stands, with CellEntityIdOffset not added to it, while the
       offset still lands on the cells copied from the input and on any boundary left to its
-      positional id.
+      positional id. A label is not shifted either, for the same reason: it was numbered above the
+      wall to begin with, and shifting it again would move the cap off the id its end is known by.
 
       Where this earns its keep is with the boundary labels in use, because then the choice
       survives the filters in between: the label of a vessel end is carried by the surface's own

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataBoundaryLabeler.cxx
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataBoundaryLabeler.cxx
@@ -81,6 +81,7 @@ vtkvmtkPolyDataBoundaryLabeler::vtkvmtkPolyDataBoundaryLabeler()
   this->SetBoundaryPointOrderArrayName(vtkvmtkBoundaryLabels::GetDefaultBoundaryPointOrderArrayName());
 
   this->LabelingMode = BOUNDARY_EXTRACTION_ORDER;
+  this->CellEntityIdOffset = 1;
   this->Annular = false;
   this->AnnularOuterBoundaryOffset = 1000;
 
@@ -182,7 +183,9 @@ int vtkvmtkPolyDataBoundaryLabeler::RequestData(
 
   // Labels already in use, so that a boundary given a fresh one never collides with a label a
   // end point asked for, or with one that is on the surface already but on no boundary any more.
-  vtkIdType highestLabelInUse = invalidLabel;
+  // It starts at the wall rather than at invalidLabel because a label is a cap's cell entity id,
+  // and the first id a cap may take is the one above the wall (see CellEntityIdOffset).
+  vtkIdType highestLabelInUse = this->CellEntityIdOffset;
 
   vtkIdType numberOfPlanes = 0;
   if ((this->LabelingMode == CLOSEST_TO_PLANE_ORIGIN || this->LabelingMode == ON_PLANE)
@@ -200,7 +203,7 @@ int vtkvmtkPolyDataBoundaryLabeler::RequestData(
   for (vtkIdType planeIndex=0; planeIndex<numberOfPlanes; planeIndex++)
     {
     planeLabels[planeIndex] = this->PlaneLabels && planeIndex < this->PlaneLabels->GetNumberOfIds()
-      ? this->PlaneLabels->GetId(planeIndex) : planeIndex;
+      ? this->PlaneLabels->GetId(planeIndex) : planeIndex+1+this->CellEntityIdOffset;
     if (planeLabels[planeIndex] > highestLabelInUse)
       {
       highestLabelInUse = planeLabels[planeIndex];
@@ -423,10 +426,13 @@ int vtkvmtkPolyDataBoundaryLabeler::RequestData(
       {
       for (vtkIdType boundaryIndex=0; boundaryIndex<numberOfBoundaries; boundaryIndex++)
         {
-        labels[boundaryIndex] = boundaryIndex;
-        if (boundaryIndex > highestLabelInUse)
+        // The id vtkvmtkCapPolyData gives the cap of the boundary in this position when it is
+        // left to number the caps itself, so that labeling a surface this way and not labeling
+        // it at all come to the same thing.
+        labels[boundaryIndex] = boundaryIndex+1+this->CellEntityIdOffset;
+        if (labels[boundaryIndex] > highestLabelInUse)
           {
-          highestLabelInUse = boundaryIndex;
+          highestLabelInUse = labels[boundaryIndex];
           }
         }
       break;

--- a/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataBoundaryLabeler.h
+++ b/vtkVmtk/ComputationalGeometry/vtkvmtkPolyDataBoundaryLabeler.h
@@ -30,11 +30,18 @@ Program:   VMTK
  * recomputed, so vtkvmtkCapPolyData and vtkvmtkPolyDataFlowExtensionsFilter can be told which
  * vessel end is which without the caller having to translate ids across each of them.
  *
+ * A boundary's label is the cell entity id its cap will carry. That is the whole point of the
+ * numbering: a cap is asked for by the same number that names the vessel end it closes, so
+ * nothing has to be translated between the point data that says which end a boundary is and the
+ * cell data a solver reads its boundary conditions off. Labels therefore start above the wall,
+ * at CellEntityIdOffset+1, rather than at zero -- see CellEntityIdOffset.
+ *
  * The labeling modes differ only in where the labels come from:
  *
- * - BoundaryExtractionOrder gives boundary i the label i, i being its position in the order
- *   vtkvmtkPolyDataBoundaryExtractor returns the boundaries in. This is what the filters do
- *   implicitly today, made explicit and, once written down, kept.
+ * - BoundaryExtractionOrder gives boundary i the label i+1+CellEntityIdOffset, i being its
+ *   position in the order vtkvmtkPolyDataBoundaryExtractor returns the boundaries in. These are
+ *   exactly the ids vtkvmtkCapPolyData would have given the caps had it been left to number them
+ *   itself, so a surface labeled this way is capped exactly as an unlabeled one is.
  * - ClosestToPlaneOrigin gives each plane's label to the boundary lying nearest its origin. The
  *   plane's normal is not used, so a caller with nothing but a position to point at a vessel end
  *   with can give the position as the origin and leave the normals unset.
@@ -57,8 +64,9 @@ Program:   VMTK
  *   neither: the boundaries are whatever the extractor finds in the mesh as it stands.
  *
  * In every mode a boundary that ends up with no label of its own is given a fresh one, above
- * every label already in use, so no two boundaries ever share a label. Planes that matched no
- * boundary are reported in UnmatchedPlaneLabels rather than passed over in silence.
+ * every label already in use and never below CellEntityIdOffset+1, so no two boundaries ever
+ * share a label and none of them is mistaken for the wall. Planes that matched no boundary are
+ * reported in UnmatchedPlaneLabels rather than passed over in silence.
  *
  * This is the class to use. It uses vtkvmtkBoundaryLabels internally -- the names of the two
  * arrays and the value that means "not on a boundary" come from there, and that class is what
@@ -139,6 +147,20 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataBoundaryLabeler : pu
 
   ///@{
   /**
+   * Set/Get the cell entity id of the wall, which the labels are numbered above. Default 1, the
+   * same value vtkvmtkCapPolyData's own CellEntityIdOffset defaults to.
+   *
+   * A label is the cell entity id of the cap that will close its boundary, and the cappers leave
+   * CellEntityIdOffset on the cells they copied from their input. So the first id a cap may take
+   * is CellEntityIdOffset+1: this is what keeps a label off the wall, and off the 0 the volume
+   * elements of a mesh carry. Set it to whatever the capper this surface will go to is set to.
+   */
+  vtkSetMacro(CellEntityIdOffset,vtkIdType);
+  vtkGetMacro(CellEntityIdOffset,vtkIdType);
+  ///@}
+
+  ///@{
+  /**
    * Set/Get whether the input is a walled surface, whose open boundaries come in pairs -- an
    * inner boundary and the outer one facing it across the wall thickness.
    *
@@ -192,7 +214,11 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataBoundaryLabeler : pu
   ///@{
   /**
    * Set/Get the label to give the boundary each plane matches. Entry i belongs to plane i. When
-   * not set, plane i is taken to carry the label i.
+   * not set, plane i is taken to carry the label i+1+CellEntityIdOffset.
+   *
+   * A label set here is taken as it stands, so a caller choosing its own is the one responsible
+   * for keeping them above the wall: a label of CellEntityIdOffset or below names a cap that
+   * cannot be told from the wall it is set into.
    */
   vtkSetObjectMacro(PlaneLabels,vtkIdList);
   vtkGetObjectMacro(PlaneLabels,vtkIdList);
@@ -254,6 +280,7 @@ class VTK_VMTK_COMPUTATIONAL_GEOMETRY_EXPORT vtkvmtkPolyDataBoundaryLabeler : pu
   char* BoundaryPointOrderArrayName;
 
   int LabelingMode;
+  vtkIdType CellEntityIdOffset;
   bool Annular;
   vtkIdType AnnularOuterBoundaryOffset;
 

--- a/vtkVmtk/Contrib/vtkvmtkConcaveAnnularCapPolyData.h
+++ b/vtkVmtk/Contrib/vtkvmtkConcaveAnnularCapPolyData.h
@@ -92,7 +92,11 @@ class VTK_VMTK_CONTRIB_EXPORT vtkvmtkConcaveAnnularCapPolyData : public vtkPolyD
    * written by vtkvmtkPolyDataBoundaryLabeler. When both are set and the input carries arrays
    * that still describe it, the boundaries are read from them instead of being extracted, and
    * the cap of each pair can be named through BoundaryCellEntityIds. With the labels in use a
-   * boundary's id is its label, and without them it is its position in the extraction order.
+   * boundary's id is its label, and without them it is its position in the extraction order.   *
+   * A label is not merely a name this filter turns into an id: it is the id. The labeler numbers
+   * the boundaries of a surface from CellEntityIdOffset+1 up, which is where this filter would
+   * have numbered their caps anyway, so the cap of a labeled boundary carries its label unchanged
+   * and a labeled surface is capped exactly as an unlabeled one is.
    */
   vtkSetStringMacro(BoundaryLabelsArrayName);
   vtkGetStringMacro(BoundaryLabelsArrayName);

--- a/vtkVmtk/Misc/vtkvmtkAnnularCapPolyData.h
+++ b/vtkVmtk/Misc/vtkvmtkAnnularCapPolyData.h
@@ -96,7 +96,11 @@ class VTK_VMTK_MISC_EXPORT vtkvmtkAnnularCapPolyData : public vtkPolyDataAlgorit
    *
    * Setting them also settles what a boundary id means everywhere else in this filter: with the
    * labels in use a boundary's id is its label, and without them it is the boundary's position
-   * in the order the extractor returns, which is what it has always been.
+   * in the order the extractor returns, which is what it has always been.   *
+   * A label is not merely a name this filter turns into an id: it is the id. The labeler numbers
+   * the boundaries of a surface from CellEntityIdOffset+1 up, which is where this filter would
+   * have numbered their caps anyway, so the cap of a labeled boundary carries its label unchanged
+   * and a labeled surface is capped exactly as an unlabeled one is.
    */
   vtkSetStringMacro(BoundaryLabelsArrayName);
   vtkGetStringMacro(BoundaryLabelsArrayName);

--- a/vtkVmtk/Misc/vtkvmtkSimpleCapPolyData.h
+++ b/vtkVmtk/Misc/vtkvmtkSimpleCapPolyData.h
@@ -95,7 +95,11 @@ class VTK_VMTK_MISC_EXPORT vtkvmtkSimpleCapPolyData : public vtkPolyDataAlgorith
    *
    * Setting them also settles what a boundary id means everywhere else in this filter: with the
    * labels in use a boundary's id is its label, and without them it is the boundary's position
-   * in the order the extractor returns, which is what it has always been.
+   * in the order the extractor returns, which is what it has always been.   *
+   * A label is not merely a name this filter turns into an id: it is the id. The labeler numbers
+   * the boundaries of a surface from CellEntityIdOffset+1 up, which is where this filter would
+   * have numbered their caps anyway, so the cap of a labeled boundary carries its label unchanged
+   * and a labeled surface is capped exactly as an unlabeled one is.
    */
   vtkSetStringMacro(BoundaryLabelsArrayName);
   vtkGetStringMacro(BoundaryLabelsArrayName);

--- a/vtkVmtk/Misc/vtkvmtkSmoothCapPolyData.h
+++ b/vtkVmtk/Misc/vtkvmtkSmoothCapPolyData.h
@@ -96,7 +96,11 @@ class VTK_VMTK_MISC_EXPORT vtkvmtkSmoothCapPolyData : public vtkPolyDataAlgorith
    *
    * Setting them also settles what a boundary id means everywhere else in this filter: with the
    * labels in use a boundary's id is its label, and without them it is the boundary's position
-   * in the order the extractor returns, which is what it has always been.
+   * in the order the extractor returns, which is what it has always been.   *
+   * A label is not merely a name this filter turns into an id: it is the id. The labeler numbers
+   * the boundaries of a surface from CellEntityIdOffset+1 up, which is where this filter would
+   * have numbered their caps anyway, so the cap of a labeled boundary carries its label unchanged
+   * and a labeled surface is capped exactly as an unlabeled one is.
    *
    * Note that this filter writes no point data on its output, the labels included: the caps it
    * builds add points of their own, and it has never carried the input's point data over.


### PR DESCRIPTION
Two fixes in the boundary labelling code, and the test surfaces they were found with.

**A boundary's label is now the id of its cap.** The labeler numbered boundaries 0, 1, 2 while the cappers put the wall at `CellEntityIdOffset` and numbered the caps above it, so the end labelled 0 became face 2 and labels 0 and 1 collided with the volume elements and the wall. Every caller had to translate, which is how an inlet condition ends up on an outlet. Labels now start above the wall (`i + 1 + CellEntityIdOffset`), which is exactly what `vtkvmtkCapPolyData` would have numbered the caps anyway. Surfaces without labels are capped identically to before, and tests pin that down.

**`GetBoundaries` returns open boundaries only.** `vtkvmtkCapPolyData` leaves the label arrays on the rim points of a boundary it closed, as a record; `GetBoundaries` handed those rings back, so an already capped surface was capped again, with a second cap over each existing one sharing its rim. The surface came back closed and nearly the right size, but every rim non-manifold, which the boundary layer generator then could not sweep. A ring is now returned only while every edge of it still has a single cell behind it, matching the documented contract with `vtkvmtkPolyDataBoundaryExtractor`. `vtkvmtkPolyDataFlowExtensionsFilter` read the same boundaries and had the same bug.

The test-data submodule is bumped to add a clipped aorta, open and capped, from `vmtk-test-data` master.
