### PR TITLE
Untangle the boundary layer from the cells around each point, and stop when it stalls

### DIFF
--- a/vtkVmtk/Misc/vtkvmtkBoundaryLayerGenerator.cxx
+++ b/vtkVmtk/Misc/vtkvmtkBoundaryLayerGenerator.cxx
@@ -59,6 +59,8 @@ vtkvmtkBoundaryLayerGenerator::vtkvmtkBoundaryLayerGenerator()
   this->NumberOfSubsteps = 2000;
   this->Relaxation = 0.01;
   this->LocalCorrectionFactor = 0.45;
+  this->MaximumUntangleRoundsWithoutImprovement = 10;
+  this->NumberOfTangledCells = 0;
 
   this->IncludeSurfaceCells = 0;
   this->IncludeSidewallCells = 0;
@@ -253,27 +255,47 @@ int vtkvmtkBoundaryLayerGenerator::RequestData(
   this->IncrementalWarpVectors(input,initialNumberOfSubsteps,relaxation);
   
   int iteration = 0;
-  int check = this->CheckTangle(input,checkArray);  
-  if (check==1)
+  int tangled = this->CheckTangle(input,checkArray);
+  if (tangled > 0)
     {
-    std::cout <<"untangle procedure.. "<<std::endl; 
+    std::cout << "untangle procedure.. " << tangled << " tangled cells" << std::endl;
     }
 
-  int maximumNumberOfIterations = this->NumberOfSubsteps / 10; 
-  while (check==1 && iteration < maximumNumberOfIterations)
+  // Each round is a local correction followed by a tenth of the sweep, and the loop may go
+  // round as many times as there are tenths - but a layer that will not untangle does not
+  // untangle in a hundred rounds either, and every round costs a sweep of the surface. So the
+  // loop also stops once a run of rounds has left the count of tangled cells no lower than the
+  // best it has been, and says so, rather than spending the full allowance to hand back the
+  // same tangle.
+  int maximumNumberOfIterations = this->NumberOfSubsteps / 10;
+  int fewestTangled = tangled;
+  int roundsWithoutImprovement = 0;
+  while (tangled > 0 && iteration < maximumNumberOfIterations)
     {
     this->LocalUntangle(input,checkArray,this->LocalCorrectionFactor);
-    this->IncrementalWarpVectors(input,intermediateNumberOfSubsteps,relaxation);   
-    //std::cout << "iteration " << iteration << std::endl;
-    check = this->CheckTangle(input,checkArray);
+    this->IncrementalWarpVectors(input,intermediateNumberOfSubsteps,relaxation);
+    tangled = this->CheckTangle(input,checkArray);
     iteration += 1;
-    if (check==0)
+    if (tangled == 0)
       {
-      std::cout <<"try last : " ;
+      std::cout << "untangle iteration " << iteration << ": untangled, sweeping the rest" << std::endl;
       this->IncrementalWarpVectors(input,finalNumberOfSubsteps,relaxation); //questo se alto tira un po la piega che altrimenti si forma
-      check = this->CheckTangle(input,checkArray); 
+      tangled = this->CheckTangle(input,checkArray);
       }
-    }  
+    std::cout << "untangle iteration " << iteration << ": " << tangled << " tangled cells" << std::endl;
+    if (tangled < fewestTangled)
+      {
+      fewestTangled = tangled;
+      roundsWithoutImprovement = 0;
+      }
+    else if (++roundsWithoutImprovement >= this->MaximumUntangleRoundsWithoutImprovement)
+      {
+      std::cout << "untangle procedure stopped: " << tangled << " cells are still tangled after "
+                << roundsWithoutImprovement << " rounds without improvement" << std::endl;
+      break;
+      }
+    }
+  this->NumberOfTangledCells = tangled;
   
   int k;
   for (k=0; k<this->NumberOfSubLayers; k++)
@@ -611,7 +633,6 @@ int vtkvmtkBoundaryLayerGenerator::CheckTangle(vtkUnstructuredGrid* input, vtkUn
   double baseNormal[3], warpedNormal[3];
   
   int found = 0;
-  int check = 0;
   for (vtkIdType j=0; j<input->GetNumberOfCells(); j++)
     {
     input->GetCellPoints(j,pointList);
@@ -644,7 +665,6 @@ int vtkvmtkBoundaryLayerGenerator::CheckTangle(vtkUnstructuredGrid* input, vtkUn
     double testArea = warpedArea / baseArea;    
     if (prod < 0 || testArea <= 0.1 )
       {
-      check = 1;
       found = found + 1;
       checkArray->SetValue(j,1); 
       }
@@ -653,10 +673,8 @@ int vtkvmtkBoundaryLayerGenerator::CheckTangle(vtkUnstructuredGrid* input, vtkUn
       checkArray->SetValue(j,0);  
       }
     }
-  //std::cout << found <<" tangle triangles found"<<std::endl;
-  
   pointList->Delete();
-  return check;
+  return found;
 }
 
 void vtkvmtkBoundaryLayerGenerator::LocalUntangle(vtkUnstructuredGrid* input, vtkUnsignedCharArray* checkArray, double alpha)
@@ -698,7 +716,7 @@ void vtkvmtkBoundaryLayerGenerator::LocalUntangle(vtkUnstructuredGrid* input, vt
         input->GetPointCells(pointList->GetId(0),cellList);
         for (int i=0; i<cellList->GetNumberOfIds();i++)
           {
-          input->GetCellPoints(i,pointList2);
+          input->GetCellPoints(cellList->GetId(i),pointList2);
           input->GetPoint(pointList2->GetId(0),point1);
           input->GetPoint(pointList2->GetId(1),point2);
           input->GetPoint(pointList2->GetId(2),point3);
@@ -711,7 +729,7 @@ void vtkvmtkBoundaryLayerGenerator::LocalUntangle(vtkUnstructuredGrid* input, vt
         input->GetPointCells(pointList->GetId(1),cellList);
         for (int i=0; i<cellList->GetNumberOfIds();i++)
           {                       
-          input->GetCellPoints(i,pointList2);
+          input->GetCellPoints(cellList->GetId(i),pointList2);
           input->GetPoint(pointList2->GetId(0),point1);
           input->GetPoint(pointList2->GetId(1),point2);
           input->GetPoint(pointList2->GetId(2),point3);
@@ -724,7 +742,7 @@ void vtkvmtkBoundaryLayerGenerator::LocalUntangle(vtkUnstructuredGrid* input, vt
         input->GetPointCells(pointList->GetId(2),cellList);
         for (int i=0; i<cellList->GetNumberOfIds();i++)
           {                       
-          input->GetCellPoints(i,pointList2);
+          input->GetCellPoints(cellList->GetId(i),pointList2);
           input->GetPoint(pointList2->GetId(0),point1);
           input->GetPoint(pointList2->GetId(1),point2);
           input->GetPoint(pointList2->GetId(2),point3);

--- a/vtkVmtk/Misc/vtkvmtkBoundaryLayerGenerator.h
+++ b/vtkVmtk/Misc/vtkvmtkBoundaryLayerGenerator.h
@@ -216,6 +216,27 @@ class VTK_VMTK_MISC_EXPORT vtkvmtkBoundaryLayerGenerator : public vtkUnstructure
 
   ///@{
   /**
+   * Set/Get how many rounds of the local untangling procedure may pass without the number of
+   * tangled elements falling below the fewest seen before the procedure gives up. Each round
+   * sweeps the surface again, so a layer that will not untangle would otherwise cost as many
+   * rounds as NumberOfSubsteps allows (a tenth of them) and still come back tangled. Default: 10.
+   */
+  vtkGetMacro(MaximumUntangleRoundsWithoutImprovement,int);
+  vtkSetMacro(MaximumUntangleRoundsWithoutImprovement,int);
+  ///@}
+
+  ///@{
+  /**
+   * Get how many elements of the layer were still tangled - inside out, or squashed to less
+   * than a tenth of their base area - when the untangling procedure ended on the last update.
+   * 0 when the sweep never tangled or the procedure untangled it; anything else says the layer
+   * folds over itself somewhere, and a mesher handed its inner surface fails or never finishes.
+   */
+  vtkGetMacro(NumberOfTangledCells,int);
+  ///@}
+
+  ///@{
+  /**
    * Set/Get the name of the cell data array used to tag every output cell (surface, sidewall, and
    * volume) with the entity id corresponding to its role (see InnerSurfaceCellEntityId,
    * OuterSurfaceCellEntityId, SidewallCellEntityId, VolumeCellEntityId). Must be set before
@@ -317,6 +338,8 @@ class VTK_VMTK_MISC_EXPORT vtkvmtkBoundaryLayerGenerator : public vtkUnstructure
 
   double Relaxation;
   double LocalCorrectionFactor;
+  int MaximumUntangleRoundsWithoutImprovement;
+  int NumberOfTangledCells;
 
   private:
   vtkvmtkBoundaryLayerGenerator(const vtkvmtkBoundaryLayerGenerator&);  // Not implemented.


### PR DESCRIPTION
## What

`vtkvmtkBoundaryLayerGenerator`'s untangle procedure could not do its job and could run for hours doing it.

- **`LocalUntangle` read the wrong cells.** Its three neighbour loops call `GetCellPoints` with the loop counter `i` instead of `cellList->GetId(i)`, so the correction applied to a tangled triangle was computed from cells 0, 1, 2… of the whole mesh rather than from the cells around its corners. Fixed to read the neighbours.
- **The untangle loop had no way out except its full allowance.** It runs up to `NumberOfSubsteps / 10` rounds (200 at vmtkmeshgenerator's default), each re-sweeping a tenth of the substeps and, whenever the tangle clears, the remaining ones. With the correction ineffective, a layer that would not untangle cost the whole allowance and came back tangled anyway; on a 50k-cell aorta at 1 mm that is hours with nothing printed, which looks like a hang. `CheckTangle` now returns the number of tangled cells, each round prints it, and the loop stops after `MaximumUntangleRoundsWithoutImprovement` rounds (new setting, default 10) that leave no fewer cells tangled than the best round so far.
- **The caller can tell.** The count at the end is kept in `NumberOfTangledCells` (getter only). A layer with any is folded over itself somewhere, and the surface inside it is not one TetGen can fill: handed such a surface it fails with "Invalid PLC" at best and works at it for a quarter of an hour at worst, so a caller can refuse it first.

## Measured

On a patient aorta (54k surface triangles) with the layer swept at a thickness factor of 1.0 over the caps at 3 mm: before, 300 s in the loop and the layer still tangled; after, the loop reports 347 → 27 tangled cells over 20 rounds and stops in about 30 s. With the default thickness factor of 0.25 the loop is never entered on that surface at 1, 2 or 3 mm, so default runs are unchanged.

## Compatibility

Default behaviour is unchanged where the sweep does not tangle. Where it does, the loop ends sooner and prints progress. `CheckTangle`'s return value changes from 0/1 to a count; it is protected and only used inside the class.
